### PR TITLE
Issueテンプレート作成

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,43 @@
+name: Bug Report
+description: バグの報告
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: バグの内容
+      description: 何が起きているか説明してください
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      description: バグを再現する手順を記載してください
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待する動作
+      description: 本来どう動作すべきか記載してください
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: 実際の動作
+      description: 実際にどう動作したか記載してください
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: 補足情報
+      description: スクリーンショットや環境情報など
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,18 @@
+name: Documentation
+description: ドキュメントの追加・修正
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 内容
+      description: 追加・修正したいドキュメントの内容を説明してください
+    validations:
+      required: true
+  - type: textarea
+    id: reason
+    attributes:
+      label: 理由
+      description: なぜこの変更が必要か記載してください
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,25 @@
+name: Enhancement
+description: 新機能の提案や既存機能の改善
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 概要
+      description: 提案する機能や改善の内容を説明してください
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: 動機
+      description: なぜこの機能・改善が必要か記載してください
+    validations:
+      required: false
+  - type: textarea
+    id: solution
+    attributes:
+      label: 実現方法の案
+      description: 実装のアイデアがあれば記載してください
+    validations:
+      required: false


### PR DESCRIPTION
Closes #3

## Summary
- bug, documentation, enhancement の3種類のIssueテンプレートを追加
- YAML形式のフォームテンプレートで、各ラベルが自動付与される

## Test plan
- [ ] GitHub上でIssue作成時にテンプレートが選択できること
- [ ] 各テンプレートで適切なラベルが自動付与されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)