### PR TITLE
chore用のIssueテンプレート追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,18 @@
+name: Chore
+description: 機能に直接関係しない雑務・設定系タスク
+labels: ["chore"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 内容
+      description: 作業内容を説明してください
+    validations:
+      required: true
+  - type: textarea
+    id: reason
+    attributes:
+      label: 理由
+      description: なぜこの作業が必要か記載してください
+    validations:
+      required: false


### PR DESCRIPTION
Closes #5

## Summary
- chore（雑務・設定系タスク）用のIssueテンプレートを追加

## Test plan
- [ ] GitHub上でIssue作成時にChoreテンプレートが選択できること
- [ ] choreラベルが自動付与されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)