### PR TITLE
feat: GitHub Actions CIワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm run build


### PR DESCRIPTION
## Summary
- PRマージ前のlint・buildチェックを自動化するGitHub Actions CIを導入
- push(main)とpull_request(main向け)をトリガーに、`npm run lint` と `npm run build` を実行

## Test plan
- [ ] このPRでCIが実行されることを確認
- [ ] lint・buildが正常に通ることを確認

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)