### PR TITLE
docs: README整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,28 @@
 
 A collection of personal utility tools built with Next.js.
 
-## Getting Started
+> **Note:** This project was created with [Claude Code](https://claude.ai/code). All coding is done by Claude Code, and humans are responsible only for review and feedback.
+
+## Tools
+
+No tools yet. New tools will be listed here as they are added.
+
+## Tech Stack
+
+- Next.js (App Router)
+- TypeScript
+- Tailwind CSS 4
+- shadcn/ui
+
+## Setup
 
 ```bash
+npm install
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Docs
+
+- [Architecture](.claude/rules/architecture.md) — Directory structure, layer separation, routing
+- [Conventions](.claude/rules/conventions.md) — Coding rules, workflow, PR guidelines
+- [CLAUDE.md](CLAUDE.md) — Commands, project overview, development guide


### PR DESCRIPTION
## Summary
- card-gamesリポジトリのREADMEに倣い、Note・Tools・Tech Stack・Setup・Docsセクションを追加
- Tech Stackは箇条書き形式に変更

Closes #49

## Test plan
- [ ] READMEの各セクションが正しく表示されること
- [ ] Docsセクションのリンク先（architecture.md, conventions.md, CLAUDE.md）が正しく開けること

🤖 Generated with [Claude Code](https://claude.com/claude-code)