### PR TITLE
enhance: git-branch-cleanupスキルを追加

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -6,6 +6,7 @@ Custom skills that automate common development workflows in this project. Each s
 
 | Skill | Command | Description |
 |-------|---------|-------------|
+| `git-branch-cleanup` | `/git-branch-cleanup` | Clean up local branches — switch to main, delete all local branches, and pull latest |
 | `git-issue-start` | `/git-issue-start <Issue number>` | Start implementation workflow from a GitHub Issue — fetch issue, validate labels, create branch, and enter plan mode |
 | `git-pr-create` | `/git-pr-create` | Create a GitHub PR from the current branch — analyze changes, check size limits, and generate PR with proper formatting |
 | `git-review-respond` | `/git-review-respond <PR number>` | Respond to GitHub PR review comments — analyze, fix code, and reply to each comment |

--- a/.claude/skills/git-branch-cleanup/SKILL.md
+++ b/.claude/skills/git-branch-cleanup/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: git-branch-cleanup
+description: Clean up local branches - switch to main, delete all local branches, and pull latest
+---
+
+# Branch Cleanup Skill
+
+PR作成・マージ後のローカルブランチクリーンアップを自動化する。mainへの切り替え・ローカルブランチ削除・最新取得を一連の流れで行う。
+
+## 処理手順
+
+### Step 1: 前提条件の確認
+
+1. `git status --porcelain` で未コミット変更を確認する
+   - 変更がある場合 → エラーを表示して終了する
+2. `git branch --show-current` で現在のブランチを取得する
+   - 既に `main` の場合 → ブランチ切り替え（Step 2）をスキップする
+
+### Step 2: mainブランチへ切り替え
+
+1. `git checkout main` を実行する
+2. 失敗した場合はエラーを表示して終了する
+
+### Step 3: ローカルブランチの削除
+
+1. `git branch` でmain以外のローカルブランチ一覧を取得する
+   - ブランチがない場合 → 「削除対象のブランチはありません」と表示してStep 4へ進む
+2. 各ブランチを `git branch -D <ブランチ名>` で削除する
+
+### Step 4: 最新取得
+
+1. `git pull` を実行する
+2. 失敗した場合はエラーを表示する
+
+### Step 5: 結果表示
+
+完了結果を以下の形式で表示する:
+
+```
+## ブランチクリーンアップ完了
+
+- 現在のブランチ: main
+- 削除したブランチ: X件
+  - <ブランチ名1>
+  - <ブランチ名2>
+- git pull: <結果サマリ>
+```


### PR DESCRIPTION
## Summary
- PR作成・マージ後のローカルブランチクリーンアップを自動化する `git-branch-cleanup` スキルを新規作成
- mainへの切り替え・ローカルブランチ削除・`git pull` を一連の流れで実行
- スキル一覧README（`.claude/skills/README.md`）にエントリを追加

Closes #100

## Test plan
- [ ] `/git-branch-cleanup` でスキルが認識されること
- [ ] SKILL.mdのフロントマター・構文が正しいこと
- [ ] README.mdのテーブルフォーマットが崩れないこと（スキル名の昇順）

🤖 Generated with [Claude Code](https://claude.com/claude-code)