### PR TITLE
enhance: CLAUDE.mdとarchitecture.mdのアーキテクチャ情報重複を解消

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -26,3 +26,9 @@
 5. **バックエンドロジックはAPIルートで。** サーバーサイドロジック（DB、外部API）が必要な場合は `app/api/` のRoute Handlersを使用する。
 6. **shadcn/uiコンポーネントを使う。** 標準的なUI要素（ボタン、カード、ダイアログなど）はshadcn/uiを使用または追加する。自作しない。
 7. **`@/` インポートエイリアスを使う。** インポートには常に `@/` プレフィックスを使用する（例: `@/components/ui/button`）。現在のfeatureより上の相対インポートは禁止。
+
+## 新しいツールの追加手順
+
+1. `src/features/<tool-name>/components/` と `src/features/<tool-name>/lib/` を作成
+2. `src/app/tools/<tool-name>/page.tsx` を作成し、featureからインポート
+3. `src/app/page.tsx` の `tools` 配列にツールのエントリを追加

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,20 +38,4 @@ src/
 └── lib/                    # 共有ユーティリティ（utils.tsなど）
 ```
 
-### レイヤー分離パターン
-
-各ツールは3層パターンに従う：
-
-1. **ルート** (`app/tools/xxx/page.tsx`) — 薄いルーティング層。features/からインポート
-2. **UI** (`features/xxx/components/`) — プレゼンテーションのみ
-3. **ロジック** (`features/xxx/lib/`) — データ取得、ビジネスロジック。DB追加時はこの層のみ変更
-
-### 新しいツールの追加手順
-
-1. `src/features/<tool-name>/components/` と `src/features/<tool-name>/lib/` を作成
-2. `src/app/tools/<tool-name>/page.tsx` を作成し、featureからインポート
-3. `src/app/page.tsx` の `tools` 配列にツールのエントリを追加
-
-### インポートエイリアス
-
-`@/*` は `./src/*` にマッピング（例: `import { Button } from "@/components/ui/button"`）
+詳細なルールは `.claude/rules/architecture.md` を参照。


### PR DESCRIPTION
## Summary
- CLAUDE.mdからレイヤー分離パターン・ツール追加手順・インポートエイリアスの重複記述を削除し、`.claude/rules/architecture.md` への参照リンクに置き換え
- architecture.mdに「新しいツールの追加手順」セクションを追加

Closes #110

## Test plan
- [ ] CLAUDE.mdのアーキテクチャセクションにディレクトリ構成図と参照リンクのみ残っていることを確認
- [ ] architecture.mdに「新しいツールの追加手順」が追加されていることを確認
- [ ] 削除した情報（レイヤー分離・インポートエイリアス・ツール追加手順）がすべてarchitecture.mdに存在することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)