### PR TITLE
enhance: Notification hookでmacOSデスクトップ通知を設定する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "osascript -e 'display notification \"Claude が入力を待っています\" with title \"Claude Code\"'"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- `.claude/settings.json` を新規作成し、Claude Code の Notification hook を設定
- Claude が入力待ち状態になった際に `osascript` で macOS デスクトップ通知を表示
- `settings.json` に設定することで git 管理・マシン間自動同期を実現

Closes #115

## Test plan
- [ ] Claude Code が PermissionRequest 等で入力待ちになった際に macOS 通知が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)