### PR TITLE
enhance: Notification hookをpermission_promptのみに絞り込む

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,10 +2,11 @@
   "hooks": {
     "Notification": [
       {
+        "matcher": "permission_prompt",
         "hooks": [
           {
             "type": "command",
-            "command": "osascript -e 'display notification \"Claude が入力を待っています\" with title \"Claude Code\"'"
+            "command": "osascript -e 'display notification \"Claude が承認を待っています\" with title \"Claude Code\"'"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Notification hook に `matcher: "permission_prompt"` を追加し、承認ダイアログ時のみ macOS 通知が発火するよう変更
- 通知メッセージを「入力を待っています」→「承認を待っています」に変更し、意図を明確化

Closes #117

## Test plan

- [ ] ツール実行の承認ダイアログが表示された際に macOS 通知が届くことを確認
- [ ] `/compact` 後やタスク完了後の idle 状態では通知が来ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)