### PR TITLE
enhance: git-branch-cleanupスキルに確認不要の実行方針を明記する

### DIFF
--- a/.claude/skills/git-branch-cleanup/SKILL.md
+++ b/.claude/skills/git-branch-cleanup/SKILL.md
@@ -7,6 +7,10 @@ description: Clean up local branches - switch to main, delete all local branches
 
 PR作成・マージ後のローカルブランチクリーンアップを自動化する。mainへの切り替え・ローカルブランチ削除・最新取得を一連の流れで行う。
 
+## 実行方針
+
+このスキルはPRマージ後のクリーンアップ用途であり、**全ステップを確認なしで一連の流れとして実行する**。`git branch -D` 等の破壊的操作も含め、途中でユーザーに承認を求めない。
+
 ## 処理手順
 
 ### Step 1: 前提条件の確認


### PR DESCRIPTION
## Summary
- `git-branch-cleanup` スキルの SKILL.md に `## 実行方針` セクションを追加
- `git branch -D` 等の破壊的操作を含む全ステップを確認なしで一連の流れとして実行することを明記

Closes #114

## Test plan
- [ ] `/git-branch-cleanup` を実行し、`git branch -D` の際に確認プロンプトが表示されず一気に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)