### PR TITLE
enhance: Claudeの作業完了時にデスクトップ通知を送るhookを追加する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "osascript -e 'display notification \"Claudeの作業が完了しました\" with title \"Claude Code\"'"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- `.claude/settings.json` に `Stop` イベントフックを追加
- Claudeの応答完了時にmacOSデスクトップ通知「Claudeの作業が完了しました」を表示する

Closes #120

## Test plan
- [ ] Claudeにタスクを実行させ、応答完了後にmacOSの通知センターに「Claudeの作業が完了しました」が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)