### PR TITLE
enhance: feature間インポートを防止するPreToolUseフックを追加する

### DIFF
--- a/.claude/hooks/check-cross-feature-import.sh
+++ b/.claude/hooks/check-cross-feature-import.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# feature間インポートを検出してブロックする
+
+# file_path を抽出
+FILE_PATH=$(echo "$TOOL_INPUT" | grep -o '"file_path":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+# src/features/<name>/ にマッチしなければ対象外
+SOURCE_FEATURE=$(echo "$FILE_PATH" | grep -o 'src/features/[^/]*' | head -1 | cut -d'/' -f3)
+if [ -z "$SOURCE_FEATURE" ]; then
+  exit 0
+fi
+
+# コンテンツから features/<name> パターンを抽出
+IMPORTED_FEATURES=$(echo "$TOOL_INPUT" | grep -oE 'features/[a-z0-9-]+' | sort -u)
+
+for IMPORT in $IMPORTED_FEATURES; do
+  TARGET_FEATURE=$(echo "$IMPORT" | cut -d'/' -f2)
+  # file_path自体にもfeatures/が含まれるのでスキップ対象に
+  if [ "$TARGET_FEATURE" != "$SOURCE_FEATURE" ] && [ -n "$TARGET_FEATURE" ]; then
+    echo "BLOCK: feature間インポート禁止 — '$SOURCE_FEATURE' から '$TARGET_FEATURE' をインポートしています。" >&2
+    echo "共有コードは src/lib/ または src/components/ に移動してください。" >&2
+    exit 2
+  fi
+done
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-cross-feature-import.sh"
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "matcher": "permission_prompt",


### PR DESCRIPTION
## Summary
- `PreToolUse`（`Edit|Write`）フックとして、feature間インポートを検出・ブロックするスクリプトを追加
- `.claude/hooks/check-cross-feature-import.sh` に検出ロジックを実装（`src/features/<X>/` 内のファイルが `src/features/<Y>/` をインポートしようとするとブロック）
- `.claude/settings.json` に `PreToolUse` エントリを追加

Closes #126

## Test plan
- [ ] `src/features/A/` 内のファイルに `@/features/B/` のインポートを書こうとするとブロックされる（exit 2）
- [ ] 同feature内のインポート（`@/features/A/lib/xxx`）はブロックされない（exit 0）
- [ ] `src/features/` 外のファイル編集はブロックされない（exit 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)