### PR TITLE
enhance: feature種類ラベル用のISSUE_TEMPLATEを追加する

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,25 @@
+name: Feature Request
+description: 新しい機能の提案
+labels: ["feature"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 概要
+      description: 提案する機能の内容を説明してください
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: 動機
+      description: なぜこの機能が必要か記載してください
+    validations:
+      required: false
+  - type: textarea
+    id: solution
+    attributes:
+      label: 実現方法の案
+      description: 実装のアイデアがあれば記載してください
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- conventions.mdの種類ラベルに定義されている `feature` に対応するISSUE_TEMPLATEが欠落していたため追加
- 既存テンプレート（enhancement.yml等）と同様の形式

Closes #131

## Test plan
- [ ] GitHubのIssue作成画面で「Feature Request」テンプレートが表示されることを確認
- [ ] テンプレートから作成したIssueに `feature` ラベルが自動付与されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)