### PR TITLE
enhance: skills/README.mdにShared Skills一覧を追加する

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,12 @@
+# Skills
+
+Custom slash commands for Claude Code, defined in `.claude/skills/`.
+
+## Shared Skills (symlinks → shared-claude-rules)
+
+- `/config-shared-sync` — Syncs shared rules and skills symlinks from shared-claude-rules
+- `/git-branch-cleanup` — Cleans up after a PR merge
+- `/git-issue-create` — Creates a GitHub Issue from conversation context
+- `/git-issue-start [issue-number]` — Fetches a GitHub Issue and creates a feature branch
+- `/git-pr-create [commit-message]` — Commits, pushes, and creates a PR
+- `/git-review-respond [pr-number]` — Handles PR review comments end-to-end


### PR DESCRIPTION
## Summary
- `.claude/skills/README.md` を新規作成し、Shared Skills（symlinks → shared-claude-rules）の一覧を記載

Closes #135

## Test plan
- [ ] README.mdの内容がcard-gamesリポジトリと整合していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)