### PR TITLE
chore: shared skillsのシンボリックリンクを同期

### DIFF
--- a/.claude/skills/config-claude-sync
+++ b/.claude/skills/config-claude-sync
@@ -1,0 +1,1 @@
+../../../shared-claude-rules/skills/config-claude-sync

--- a/.claude/skills/config-github-sync
+++ b/.claude/skills/config-github-sync
@@ -1,0 +1,1 @@
+../../../shared-claude-rules/skills/config-github-sync

--- a/.claude/skills/config-shared-sync
+++ b/.claude/skills/config-shared-sync
@@ -1,1 +1,0 @@
-../../../shared-claude-rules/skills/config-shared-sync


### PR DESCRIPTION
## Summary
- `config-shared-sync` → `config-claude-sync` にリネーム（shared側の名称変更に追従）
- `config-github-sync` を新規追加

## Test plan
- [ ] `/config-claude-sync` が正常に動作すること
- [ ] `/config-github-sync` が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)