### PR TITLE
enhance: READMEに多言語対応（英語・日本語切り替え）を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Language:** English | [日本語](docs/ja-JP/README.md)
+
 # Personal Tools
 
 A collection of personal utility tools built with Next.js.

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -1,0 +1,37 @@
+**Language:** [English](../../README.md) | 日本語
+
+# Personal Tools
+
+個人ユーティリティツール集。Next.jsで構築。
+
+> **注記:** このプロジェクトは[Claude Code](https://claude.ai/code)によって作成されました。コーディングはすべてClaude Codeが行い、人間はレビューとフィードバックのみを担当します。
+
+## ツール
+
+| ツール | 説明 | パス |
+|--------|------|------|
+| UUID Generator | UUID v4/v7とULIDを生成。一括生成とクリップボードコピーに対応 | `/tools/uuid-generator` |
+| Text Rewriter | トーン変換・翻訳・要約・校正によるテキスト書き換え（Gemini搭載） | `/tools/text-rewriter` |
+| JSON Formatter | JSONのフォーマット・圧縮・検証。ツリービューとパスフィルター付き | `/tools/json-formatter` |
+
+## 技術スタック
+
+- Next.js (App Router)
+- TypeScript
+- Tailwind CSS 4
+- shadcn/ui
+
+## セットアップ
+
+```bash
+npm install
+cp .env.local.example .env.local
+# .env.localを編集し、必要な変数を設定する
+npm run dev
+```
+
+## ドキュメント
+
+- [アーキテクチャ](../../.claude/rules/architecture.md) — ディレクトリ構成、レイヤー分離、ルーティング
+- [コーディング規約](../../.claude/rules/conventions.md) — コーディングルール、ワークフロー、PRガイドライン
+- [CLAUDE.md](../../CLAUDE.md) — コマンド、プロジェクト概要、開発ガイド


### PR DESCRIPTION
## Summary

- `README.md` の冒頭にLanguageセクションを追加（タイトル前に `**Language:** English | 日本語` 形式で配置）
- `docs/ja-JP/README.md` を新規作成し、英語版READMEの日本語訳を整備
- 各ファイルから相手言語版へのリンクを設置（現在のファイル自身はプレーンテキスト）

Closes #146

## Test plan

- [ ] `README.md` の日本語リンクが `docs/ja-JP/README.md` に正しく遷移する
- [ ] `docs/ja-JP/README.md` の English リンクがルートの `README.md` に正しく遷移する

🤖 Generated with [Claude Code](https://claude.com/claude-code)