### PR TITLE
enhance: force pushをブロックするPreToolUse hookを追加する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,15 @@
             "command": "bash .claude/hooks/check-cross-feature-import.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$TOOL_INPUT\" | grep -qE 'push\\s+(-f|--force)'; then echo 'BLOCK: force pushは禁止されています' >&2; exit 2; fi"
+          }
+        ]
       }
     ],
     "Notification": [


### PR DESCRIPTION
## Summary
- `.claude/settings.json` の `PreToolUse` に `Bash` matcher hookを追加
- `git push --force` / `git push -f` を検出してブロック（exit 2）
- 通常の `git push` はブロックしない

Closes #121

## Test plan
- [ ] `git push --force` 実行時にブロックされること
- [ ] `git push -f` 実行時にブロックされること
- [ ] 通常の `git push origin main` はブロックされないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)