### PR TITLE
enhance: shadcn/uiコンポーネントの手動編集をブロックするPreToolUse hookを追加する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,15 @@
             "command": "if echo \"$TOOL_INPUT\" | grep -qE 'push\\s+(-f|--force)'; then echo 'BLOCK: force pushは禁止されています' >&2; exit 2; fi"
           }
         ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$TOOL_INPUT\" | grep -q 'src/components/ui/'; then echo 'BLOCK: shadcn/uiコンポーネントは手動編集禁止です。npx shadcn@latest add で管理してください' >&2; exit 2; fi"
+          }
+        ]
       }
     ],
     "Notification": [


### PR DESCRIPTION
## Summary
- `.claude/settings.json` の `PreToolUse` 配列に `Edit` matcher のhookを追加
- `src/components/ui/` 配下のファイルへのEdit操作を自動ブロックし、shadcn/uiコンポーネントの手動編集を防止する
- ブロック時のメッセージで `npx shadcn@latest add` の使用を促す

Closes #122

## Test plan
- [ ] `src/components/ui/button.tsx` へのEdit → ブロックされること
- [ ] `src/components/navigation.tsx` へのEdit → ブロックされないこと
- [ ] `src/features/` 配下のファイルへのEdit → ブロックされないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)