### PR TITLE
enhance: .envファイルのgit addをブロックするPreToolUse hookを追加する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,15 @@
             "command": "if echo \"$TOOL_INPUT\" | grep -q 'src/components/ui/'; then echo 'BLOCK: shadcn/uiコンポーネントは手動編集禁止です。npx shadcn@latest add で管理してください' >&2; exit 2; fi"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$TOOL_INPUT\" | grep -qE 'git\\s+add.*\\.env'; then echo 'BLOCK: .envファイルのステージングは禁止されています' >&2; exit 2; fi"
+          }
+        ]
       }
     ],
     "Notification": [


### PR DESCRIPTION
## Summary
- `.claude/settings.json` の `PreToolUse` 配列に `Bash` matcher の hook を追加
- `git add *.env*` パターンのコマンドを検出してブロック（`git add -f` 等の強制ステージングも含む）
- `.gitignore` による除外と合わせた二重ガードで機密情報の誤コミットを防止

Closes #123

## Test plan
- [ ] `git add .env` がブロックされること
- [ ] `git add .env.local` がブロックされること
- [ ] `git add src/app/page.tsx` など通常ファイルの `git add` はブロックされないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)