### PR TITLE
chore: プロジェクトの.gitignoreから.claude/settings.local.jsonの除外設定を削除する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,3 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-
-# claude
-.claude/settings.local.json


### PR DESCRIPTION
## 概要

グローバルの `.gitignore` で `.claude/settings.local.json` が管理されるため、プロジェクトの `.gitignore` から重複する設定を削除する。

## 変更点

- `.gitignore` から `# claude` セクションと `.claude/settings.local.json` の記述を削除

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)