### PR TITLE
feat: 正規表現テスターツールを追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, Braces, Clock, FileText, Fingerprint, FileDiff, Languages, Palette, Package, Type, type LucideIcon } from "lucide-react";
+import { ArrowRight, Braces, Clock, FileText, Fingerprint, FileDiff, Languages, Palette, Package, Regex, Type, type LucideIcon } from "lucide-react";
 import {
   Card,
   CardHeader,
@@ -68,6 +68,12 @@ const tools: Tool[] = [
     description: "文字数・単語数・行数・バイト数のリアルタイムカウント、プラットフォーム別残り文字数表示",
     href: "/tools/character-counter",
     icon: Type,
+  },
+  {
+    name: "Regex Tester",
+    description: "正規表現のパターンマッチをリアルタイムで検証、キャプチャグループ表示、置換プレビュー",
+    href: "/tools/regex-tester",
+    icon: Regex,
   },
 ];
 

--- a/src/app/tools/regex-tester/page.tsx
+++ b/src/app/tools/regex-tester/page.tsx
@@ -1,0 +1,5 @@
+import { RegexTesterPage } from "@/features/regex-tester/components/regex-tester-page";
+
+export default function Page() {
+  return <RegexTesterPage />;
+}

--- a/src/app/tools/regex-tester/page.tsx
+++ b/src/app/tools/regex-tester/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from "next";
 import { RegexTesterPage } from "@/features/regex-tester/components/regex-tester-page";
+
+export const metadata: Metadata = {
+  title: "Regex Tester - Personal Tools",
+  description: "正規表現のパターンマッチをリアルタイムで検証",
+};
 
 export default function Page() {
   return <RegexTesterPage />;

--- a/src/features/regex-tester/components/capture-groups.tsx
+++ b/src/features/regex-tester/components/capture-groups.tsx
@@ -1,0 +1,49 @@
+import { Badge } from "@/components/ui/badge";
+import type { MatchResult } from "../lib/types";
+
+type CaptureGroupsProps = {
+  matches: MatchResult[];
+};
+
+export function CaptureGroups({ matches }: CaptureGroupsProps) {
+  const matchesWithGroups = matches.filter((m) => m.groups.length > 0);
+  if (matchesWithGroups.length === 0) return null;
+
+  return (
+    <div className="space-y-3">
+      <h2 className="text-sm font-medium">キャプチャグループ</h2>
+      <div className="space-y-3">
+        {matchesWithGroups.map((match, mi) => (
+          <div key={mi} className="rounded-md border p-3">
+            <div className="mb-2 flex items-center gap-2">
+              <Badge variant="outline">マッチ {mi + 1}</Badge>
+              <code className="text-sm text-muted-foreground">
+                {match.fullMatch}
+              </code>
+            </div>
+            <div className="space-y-1">
+              {match.groups.map((group) => (
+                <div
+                  key={group.index}
+                  className="flex items-center gap-2 text-sm"
+                >
+                  <span className="w-8 text-right font-mono text-muted-foreground">
+                    ${group.index}
+                  </span>
+                  {group.name && (
+                    <Badge variant="secondary" className="font-mono text-xs">
+                      {group.name}
+                    </Badge>
+                  )}
+                  <code className="rounded bg-muted px-1.5 py-0.5">
+                    {group.value}
+                  </code>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/regex-tester/components/match-highlight.tsx
+++ b/src/features/regex-tester/components/match-highlight.tsx
@@ -1,0 +1,34 @@
+import { Badge } from "@/components/ui/badge";
+import type { TextSegment } from "../lib/types";
+
+type MatchHighlightProps = {
+  segments: TextSegment[];
+  matchCount: number;
+};
+
+export function MatchHighlight({ segments, matchCount }: MatchHighlightProps) {
+  if (segments.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <h2 className="text-sm font-medium">マッチ結果</h2>
+        <Badge variant="secondary">{matchCount}件</Badge>
+      </div>
+      <div className="rounded-md border bg-muted/50 p-4 font-mono text-sm whitespace-pre-wrap break-all">
+        {segments.map((seg, i) =>
+          seg.type === "text" ? (
+            <span key={i}>{seg.value}</span>
+          ) : (
+            <mark
+              key={i}
+              className="rounded-sm bg-yellow-200 px-0.5 dark:bg-yellow-800"
+            >
+              {seg.value}
+            </mark>
+          ),
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/regex-tester/components/pattern-input.tsx
+++ b/src/features/regex-tester/components/pattern-input.tsx
@@ -1,0 +1,71 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import type { RegexFlag, RegexFlags } from "../lib/types";
+
+type PatternInputProps = {
+  pattern: string;
+  flags: RegexFlags;
+  error: string | null;
+  onPatternChange: (value: string) => void;
+  onFlagToggle: (flag: RegexFlag) => void;
+};
+
+const FLAG_LABELS: { flag: RegexFlag; label: string; description: string }[] = [
+  { flag: "g", label: "g", description: "global" },
+  { flag: "i", label: "i", description: "case-insensitive" },
+  { flag: "m", label: "m", description: "multiline" },
+  { flag: "s", label: "s", description: "dotAll" },
+];
+
+export function PatternInput({
+  pattern,
+  flags,
+  error,
+  onPatternChange,
+  onFlagToggle,
+}: PatternInputProps) {
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label htmlFor="regex-pattern">正規表現パターン</Label>
+        <div className="flex items-center gap-2">
+          <span className="text-muted-foreground font-mono text-sm">/</span>
+          <Input
+            id="regex-pattern"
+            value={pattern}
+            onChange={(e) => onPatternChange(e.target.value)}
+            placeholder="[a-z]+"
+            className="font-mono text-sm"
+          />
+          <span className="text-muted-foreground font-mono text-sm">/</span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4">
+        {FLAG_LABELS.map(({ flag, label, description }) => (
+          <div key={flag} className="flex items-center gap-1.5">
+            <Switch
+              id={`flag-${flag}`}
+              checked={flags[flag]}
+              onCheckedChange={() => onFlagToggle(flag)}
+              aria-label={`${description}フラグ`}
+            />
+            <Label
+              htmlFor={`flag-${flag}`}
+              className="cursor-pointer font-mono text-sm"
+            >
+              {label}
+            </Label>
+          </div>
+        ))}
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/regex-tester/components/preset-select.tsx
+++ b/src/features/regex-tester/components/preset-select.tsx
@@ -1,0 +1,37 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { PRESETS } from "../lib/presets";
+import type { Preset } from "../lib/types";
+
+type PresetSelectProps = {
+  onSelect: (preset: Preset) => void;
+};
+
+export function PresetSelect({ onSelect }: PresetSelectProps) {
+  return (
+    <div className="space-y-2">
+      <Select
+        onValueChange={(value) => {
+          const preset = PRESETS.find((p) => p.name === value);
+          if (preset) onSelect(preset);
+        }}
+      >
+        <SelectTrigger className="w-full sm:w-64">
+          <SelectValue placeholder="プリセットパターンを選択..." />
+        </SelectTrigger>
+        <SelectContent>
+          {PRESETS.map((preset) => (
+            <SelectItem key={preset.name} value={preset.name}>
+              {preset.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/features/regex-tester/components/preset-select.tsx
+++ b/src/features/regex-tester/components/preset-select.tsx
@@ -5,6 +5,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
 import { PRESETS } from "../lib/presets";
 import type { Preset } from "../lib/types";
 
@@ -15,13 +16,16 @@ type PresetSelectProps = {
 export function PresetSelect({ onSelect }: PresetSelectProps) {
   return (
     <div className="space-y-2">
+      <Label htmlFor="preset-select" className="sr-only">
+        プリセットパターン
+      </Label>
       <Select
         onValueChange={(value) => {
           const preset = PRESETS.find((p) => p.name === value);
           if (preset) onSelect(preset);
         }}
       >
-        <SelectTrigger className="w-full sm:w-64">
+        <SelectTrigger id="preset-select" className="w-full sm:w-64">
           <SelectValue placeholder="プリセットパターンを選択..." />
         </SelectTrigger>
         <SelectContent>

--- a/src/features/regex-tester/components/regex-tester-page.tsx
+++ b/src/features/regex-tester/components/regex-tester-page.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Eraser } from "lucide-react";
+import { useRegexTester } from "../lib/use-regex-tester";
+import { PatternInput } from "./pattern-input";
+import { TestInput } from "./test-input";
+import { MatchHighlight } from "./match-highlight";
+import { CaptureGroups } from "./capture-groups";
+import { PresetSelect } from "./preset-select";
+import { ReplacePreview } from "./replace-preview";
+
+export function RegexTesterPage() {
+  const {
+    pattern,
+    setPattern,
+    flags,
+    testString,
+    setTestString,
+    replacement,
+    setReplacement,
+    regexResult,
+    segments,
+    replaceResult,
+    handleFlagToggle,
+    handlePresetSelect,
+    handleClear,
+  } = useRegexTester();
+
+  const matches = regexResult.success ? regexResult.matches : [];
+  const error = regexResult.success ? null : regexResult.error;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Regex Tester</h1>
+        <p className="mt-2 text-muted-foreground">
+          正規表現のパターンマッチをリアルタイムで検証できます。
+        </p>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <PresetSelect onSelect={handlePresetSelect} />
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleClear}
+          disabled={!pattern && !testString}
+        >
+          <Eraser className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
+          クリア
+        </Button>
+      </div>
+
+      <PatternInput
+        pattern={pattern}
+        flags={flags}
+        error={error}
+        onPatternChange={setPattern}
+        onFlagToggle={handleFlagToggle}
+      />
+
+      <TestInput value={testString} onChange={setTestString} />
+
+      <MatchHighlight segments={segments} matchCount={matches.length} />
+
+      <CaptureGroups matches={matches} />
+
+      <ReplacePreview
+        replacement={replacement}
+        replaceResult={replaceResult}
+        hasMatches={matches.length > 0}
+        onReplacementChange={setReplacement}
+      />
+    </div>
+  );
+}

--- a/src/features/regex-tester/components/replace-preview.tsx
+++ b/src/features/regex-tester/components/replace-preview.tsx
@@ -1,0 +1,40 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type ReplacePreviewProps = {
+  replacement: string;
+  replaceResult: string | null;
+  hasMatches: boolean;
+  onReplacementChange: (value: string) => void;
+};
+
+export function ReplacePreview({
+  replacement,
+  replaceResult,
+  hasMatches,
+  onReplacementChange,
+}: ReplacePreviewProps) {
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <Label htmlFor="replacement">置換文字列</Label>
+        <Input
+          id="replacement"
+          value={replacement}
+          onChange={(e) => onReplacementChange(e.target.value)}
+          placeholder="$1, $<name>, $& などが使えます"
+          className="font-mono text-sm"
+        />
+      </div>
+
+      {replacement && hasMatches && replaceResult !== null && (
+        <div className="space-y-2">
+          <h2 className="text-sm font-medium">置換結果</h2>
+          <div className="rounded-md border bg-muted/50 p-4 font-mono text-sm whitespace-pre-wrap break-all">
+            {replaceResult}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/regex-tester/components/test-input.tsx
+++ b/src/features/regex-tester/components/test-input.tsx
@@ -1,0 +1,22 @@
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+
+type TestInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export function TestInput({ value, onChange }: TestInputProps) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor="test-string">テスト文字列</Label>
+      <Textarea
+        id="test-string"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="マッチさせたいテキストを入力..."
+        className="min-h-32 font-mono text-sm"
+      />
+    </div>
+  );
+}

--- a/src/features/regex-tester/lib/__tests__/presets.test.ts
+++ b/src/features/regex-tester/lib/__tests__/presets.test.ts
@@ -1,0 +1,40 @@
+import { PRESETS } from "../presets";
+import { buildRegex, findMatches } from "../regex-engine";
+
+describe("PRESETS", () => {
+  it("has at least one preset", () => {
+    expect(PRESETS.length).toBeGreaterThan(0);
+  });
+
+  it.each(PRESETS.map((p) => [p.name, p]))(
+    "%s has required fields",
+    (_name, preset) => {
+      expect(preset.name).toBeTruthy();
+      expect(preset.pattern).toBeTruthy();
+      expect(preset.description).toBeTruthy();
+      expect(preset.testExample).toBeTruthy();
+    },
+  );
+
+  it.each(PRESETS.map((p) => [p.name, p]))(
+    "%s compiles to a valid RegExp",
+    (_name, preset) => {
+      expect(() => buildRegex(preset.pattern, preset.flags)).not.toThrow();
+    },
+  );
+
+  it.each(PRESETS.map((p) => [p.name, p]))(
+    "%s matches its own test example",
+    (_name, preset) => {
+      const result = findMatches(
+        preset.pattern,
+        preset.flags,
+        preset.testExample,
+      );
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.matches.length).toBeGreaterThan(0);
+      }
+    },
+  );
+});

--- a/src/features/regex-tester/lib/__tests__/regex-engine.test.ts
+++ b/src/features/regex-tester/lib/__tests__/regex-engine.test.ts
@@ -1,0 +1,194 @@
+import {
+  buildRegex,
+  findMatches,
+  buildSegments,
+  computeReplacement,
+} from "../regex-engine";
+import type { RegexFlags, MatchResult } from "../types";
+
+const defaultFlags: RegexFlags = { g: true, i: false, m: false, s: false };
+
+describe("buildRegex", () => {
+  it("builds a RegExp with the specified flags", () => {
+    const regex = buildRegex("abc", { g: true, i: true, m: false, s: false });
+    expect(regex.source).toBe("abc");
+    expect(regex.flags).toContain("g");
+    expect(regex.flags).toContain("i");
+    expect(regex.flags).not.toContain("m");
+  });
+
+  it("throws on invalid pattern", () => {
+    expect(() => buildRegex("[", defaultFlags)).toThrow();
+  });
+});
+
+describe("findMatches", () => {
+  it("returns empty matches for empty pattern", () => {
+    const result = findMatches("", defaultFlags, "test");
+    expect(result).toEqual({ success: true, matches: [] });
+  });
+
+  it("returns error for invalid regex", () => {
+    const result = findMatches("[", defaultFlags, "test");
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeTruthy();
+    }
+  });
+
+  it("finds multiple matches with global flag", () => {
+    const result = findMatches("\\d+", defaultFlags, "abc 123 def 456");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.matches).toHaveLength(2);
+      expect(result.matches[0].fullMatch).toBe("123");
+      expect(result.matches[0].start).toBe(4);
+      expect(result.matches[0].end).toBe(7);
+      expect(result.matches[1].fullMatch).toBe("456");
+      expect(result.matches[1].start).toBe(12);
+      expect(result.matches[1].end).toBe(15);
+    }
+  });
+
+  it("finds at most one match without global flag", () => {
+    const flags: RegexFlags = { g: false, i: false, m: false, s: false };
+    const result = findMatches("\\d+", flags, "abc 123 def 456");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.matches).toHaveLength(1);
+      expect(result.matches[0].fullMatch).toBe("123");
+    }
+  });
+
+  it("extracts numbered capture groups", () => {
+    const result = findMatches("(\\w+)@(\\w+)", defaultFlags, "user@host");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.matches).toHaveLength(1);
+      const groups = result.matches[0].groups;
+      expect(groups).toHaveLength(2);
+      expect(groups[0]).toEqual({ index: 1, name: null, value: "user" });
+      expect(groups[1]).toEqual({ index: 2, name: null, value: "host" });
+    }
+  });
+
+  it("extracts named capture groups", () => {
+    const result = findMatches(
+      "(?<user>\\w+)@(?<domain>\\w+)",
+      defaultFlags,
+      "user@host",
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const groups = result.matches[0].groups;
+      expect(groups[0]).toEqual({ index: 1, name: "user", value: "user" });
+      expect(groups[1]).toEqual({ index: 2, name: "domain", value: "host" });
+    }
+  });
+
+  it("handles zero-length matches without infinite loop", () => {
+    const result = findMatches("(?=a)", defaultFlags, "aaa");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.matches.length).toBeGreaterThan(0);
+      expect(result.matches.length).toBeLessThanOrEqual(10000);
+    }
+  });
+
+  it("respects case-insensitive flag", () => {
+    const flags: RegexFlags = { g: true, i: true, m: false, s: false };
+    const result = findMatches("abc", flags, "ABC abc");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.matches).toHaveLength(2);
+    }
+  });
+});
+
+describe("buildSegments", () => {
+  it("returns empty array for empty string", () => {
+    expect(buildSegments("", [])).toEqual([]);
+  });
+
+  it("returns single text segment when no matches", () => {
+    expect(buildSegments("hello", [])).toEqual([
+      { type: "text", value: "hello" },
+    ]);
+  });
+
+  it("splits text around a single match", () => {
+    const matches: MatchResult[] = [
+      { fullMatch: "world", start: 6, end: 11, groups: [] },
+    ];
+    const segments = buildSegments("hello world!", matches);
+    expect(segments).toEqual([
+      { type: "text", value: "hello " },
+      { type: "match", value: "world", matchIndex: 0 },
+      { type: "text", value: "!" },
+    ]);
+  });
+
+  it("handles match at start of string", () => {
+    const matches: MatchResult[] = [
+      { fullMatch: "hello", start: 0, end: 5, groups: [] },
+    ];
+    const segments = buildSegments("hello world", matches);
+    expect(segments).toEqual([
+      { type: "match", value: "hello", matchIndex: 0 },
+      { type: "text", value: " world" },
+    ]);
+  });
+
+  it("handles match at end of string", () => {
+    const matches: MatchResult[] = [
+      { fullMatch: "world", start: 6, end: 11, groups: [] },
+    ];
+    const segments = buildSegments("hello world", matches);
+    expect(segments).toEqual([
+      { type: "text", value: "hello " },
+      { type: "match", value: "world", matchIndex: 0 },
+    ]);
+  });
+
+  it("handles multiple adjacent matches", () => {
+    const matches: MatchResult[] = [
+      { fullMatch: "ab", start: 0, end: 2, groups: [] },
+      { fullMatch: "cd", start: 2, end: 4, groups: [] },
+    ];
+    const segments = buildSegments("abcd", matches);
+    expect(segments).toEqual([
+      { type: "match", value: "ab", matchIndex: 0 },
+      { type: "match", value: "cd", matchIndex: 1 },
+    ]);
+  });
+});
+
+describe("computeReplacement", () => {
+  it("returns null for empty pattern", () => {
+    expect(computeReplacement("", defaultFlags, "test", "x")).toBeNull();
+  });
+
+  it("returns null for invalid regex", () => {
+    expect(computeReplacement("[", defaultFlags, "test", "x")).toBeNull();
+  });
+
+  it("replaces matches with replacement string", () => {
+    const result = computeReplacement("\\d+", defaultFlags, "a1b2c3", "X");
+    expect(result).toBe("aXbXcX");
+  });
+
+  it("supports back-references in replacement", () => {
+    const result = computeReplacement(
+      "(\\w+)@(\\w+)",
+      defaultFlags,
+      "user@host",
+      "$2@$1",
+    );
+    expect(result).toBe("host@user");
+  });
+
+  it("replaces empty string for empty replacement", () => {
+    const result = computeReplacement("\\d+", defaultFlags, "a1b2", "");
+    expect(result).toBe("ab");
+  });
+});

--- a/src/features/regex-tester/lib/presets.ts
+++ b/src/features/regex-tester/lib/presets.ts
@@ -1,0 +1,49 @@
+import type { Preset } from "./types";
+
+const FLAGS_G = { g: true, i: false, m: false, s: false } as const;
+const FLAGS_GI = { g: true, i: true, m: false, s: false } as const;
+
+export const PRESETS: Preset[] = [
+  {
+    name: "メールアドレス",
+    pattern: "[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}",
+    flags: FLAGS_GI,
+    description: "一般的なメールアドレスにマッチ",
+    testExample: "連絡先: user@example.com または admin@test.co.jp まで",
+  },
+  {
+    name: "URL",
+    pattern: "https?://[\\w\\-]+(\\.[\\w\\-]+)+[\\w.,@?^=%&:/~+#\\-]*",
+    flags: FLAGS_G,
+    description: "HTTP/HTTPSのURLにマッチ",
+    testExample: "詳細は https://example.com/path?q=1 を参照",
+  },
+  {
+    name: "電話番号（日本）",
+    pattern: "0\\d{1,4}-\\d{1,4}-\\d{4}",
+    flags: FLAGS_G,
+    description: "ハイフン区切りの日本の電話番号にマッチ",
+    testExample: "TEL: 03-1234-5678 / 090-1234-5678",
+  },
+  {
+    name: "日付（YYYY-MM-DD）",
+    pattern: "\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])",
+    flags: FLAGS_G,
+    description: "ISO 8601形式の日付にマッチ",
+    testExample: "開始日: 2026-03-29 終了日: 2026-12-31",
+  },
+  {
+    name: "IPv4アドレス",
+    pattern: "\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b",
+    flags: FLAGS_G,
+    description: "IPv4アドレスにマッチ",
+    testExample: "サーバー: 192.168.1.1 ゲートウェイ: 10.0.0.1",
+  },
+  {
+    name: "HTMLタグ",
+    pattern: "<([a-zA-Z][a-zA-Z0-9]*)\\b[^>]*>(.*?)</\\1>",
+    flags: { g: true, i: false, m: false, s: true },
+    description: "開始タグと閉じタグのペアにマッチ",
+    testExample: '<div class="x">content</div><span>text</span>',
+  },
+];

--- a/src/features/regex-tester/lib/regex-engine.ts
+++ b/src/features/regex-tester/lib/regex-engine.ts
@@ -1,0 +1,133 @@
+import type {
+  RegexFlags,
+  RegexResult,
+  MatchResult,
+  CaptureGroup,
+  TextSegment,
+} from "./types";
+
+const MAX_MATCH_ITERATIONS = 10000;
+
+export function buildRegex(pattern: string, flags: RegexFlags): RegExp {
+  const flagStr = (Object.keys(flags) as (keyof RegexFlags)[])
+    .filter((f) => flags[f])
+    .join("");
+  return new RegExp(pattern, flagStr);
+}
+
+export function findMatches(
+  pattern: string,
+  flags: RegexFlags,
+  testString: string,
+): RegexResult {
+  if (pattern === "") {
+    return { success: true, matches: [] };
+  }
+
+  let regex: RegExp;
+  try {
+    regex = buildRegex(pattern, flags);
+  } catch (e) {
+    return {
+      success: false,
+      error: e instanceof SyntaxError ? e.message : String(e),
+    };
+  }
+
+  const matches: MatchResult[] = [];
+
+  if (flags.g) {
+    let match: RegExpExecArray | null;
+    let iterations = 0;
+    while ((match = regex.exec(testString)) !== null) {
+      matches.push(toMatchResult(match));
+      if (match[0].length === 0) {
+        regex.lastIndex++;
+      }
+      iterations++;
+      if (iterations >= MAX_MATCH_ITERATIONS) break;
+    }
+  } else {
+    const match = regex.exec(testString);
+    if (match) {
+      matches.push(toMatchResult(match));
+    }
+  }
+
+  return { success: true, matches };
+}
+
+function toMatchResult(match: RegExpExecArray): MatchResult {
+  const groups: CaptureGroup[] = [];
+  const namedGroups = match.groups ?? {};
+  const nameByIndex = new Map<number, string>();
+
+  // Map named groups to their indices by matching values in order
+  const usedIndices = new Set<number>();
+  for (const [name, value] of Object.entries(namedGroups)) {
+    for (let i = 1; i < match.length; i++) {
+      if (!usedIndices.has(i) && match[i] === value) {
+        nameByIndex.set(i, name);
+        usedIndices.add(i);
+        break;
+      }
+    }
+  }
+
+  for (let i = 1; i < match.length; i++) {
+    groups.push({
+      index: i,
+      name: nameByIndex.get(i) ?? null,
+      value: match[i] ?? "",
+    });
+  }
+
+  return {
+    fullMatch: match[0],
+    start: match.index,
+    end: match.index + match[0].length,
+    groups,
+  };
+}
+
+export function buildSegments(
+  testString: string,
+  matches: MatchResult[],
+): TextSegment[] {
+  if (matches.length === 0) {
+    return testString ? [{ type: "text", value: testString }] : [];
+  }
+
+  const segments: TextSegment[] = [];
+  let cursor = 0;
+
+  for (let i = 0; i < matches.length; i++) {
+    const m = matches[i];
+    if (m.start > cursor) {
+      segments.push({ type: "text", value: testString.slice(cursor, m.start) });
+    }
+    segments.push({ type: "match", value: m.fullMatch, matchIndex: i });
+    cursor = m.end;
+  }
+
+  if (cursor < testString.length) {
+    segments.push({ type: "text", value: testString.slice(cursor) });
+  }
+
+  return segments;
+}
+
+export function computeReplacement(
+  pattern: string,
+  flags: RegexFlags,
+  testString: string,
+  replacement: string,
+): string | null {
+  if (pattern === "") return null;
+  try {
+    const regex = buildRegex(pattern, flags);
+    return testString.replace(regex, replacement);
+  } catch {
+    return null;
+  }
+}

--- a/src/features/regex-tester/lib/types.ts
+++ b/src/features/regex-tester/lib/types.ts
@@ -1,0 +1,32 @@
+export type RegexFlag = "g" | "i" | "m" | "s";
+
+export type RegexFlags = Record<RegexFlag, boolean>;
+
+export type CaptureGroup = {
+  index: number;
+  name: string | null;
+  value: string;
+};
+
+export type MatchResult = {
+  fullMatch: string;
+  start: number;
+  end: number;
+  groups: CaptureGroup[];
+};
+
+export type RegexResult =
+  | { success: true; matches: MatchResult[] }
+  | { success: false; error: string };
+
+export type TextSegment =
+  | { type: "text"; value: string }
+  | { type: "match"; value: string; matchIndex: number };
+
+export type Preset = {
+  name: string;
+  pattern: string;
+  flags: RegexFlags;
+  description: string;
+  testExample: string;
+};

--- a/src/features/regex-tester/lib/use-regex-tester.ts
+++ b/src/features/regex-tester/lib/use-regex-tester.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState, useMemo, useCallback } from "react";
+import type { RegexFlag, RegexFlags, Preset } from "./types";
+import { findMatches, buildSegments, computeReplacement } from "./regex-engine";
+
+const DEFAULT_FLAGS: RegexFlags = { g: true, i: false, m: false, s: false };
+
+export function useRegexTester() {
+  const [pattern, setPattern] = useState("");
+  const [flags, setFlags] = useState<RegexFlags>(DEFAULT_FLAGS);
+  const [testString, setTestString] = useState("");
+  const [replacement, setReplacement] = useState("");
+
+  const regexResult = useMemo(
+    () => findMatches(pattern, flags, testString),
+    [pattern, flags, testString],
+  );
+
+  const segments = useMemo(() => {
+    if (!regexResult.success) return [];
+    return buildSegments(testString, regexResult.matches);
+  }, [testString, regexResult]);
+
+  const replaceResult = useMemo(() => {
+    if (!replacement) return null;
+    return computeReplacement(pattern, flags, testString, replacement);
+  }, [pattern, flags, testString, replacement]);
+
+  const handleFlagToggle = useCallback((flag: RegexFlag) => {
+    setFlags((prev) => ({ ...prev, [flag]: !prev[flag] }));
+  }, []);
+
+  const handlePresetSelect = useCallback((preset: Preset) => {
+    setPattern(preset.pattern);
+    setFlags({ ...preset.flags });
+    setTestString(preset.testExample);
+    setReplacement("");
+  }, []);
+
+  const handleClear = useCallback(() => {
+    setPattern("");
+    setFlags(DEFAULT_FLAGS);
+    setTestString("");
+    setReplacement("");
+  }, []);
+
+  return {
+    pattern,
+    setPattern,
+    flags,
+    testString,
+    setTestString,
+    replacement,
+    setReplacement,
+    regexResult,
+    segments,
+    replaceResult,
+    handleFlagToggle,
+    handlePresetSelect,
+    handleClear,
+  };
+}


### PR DESCRIPTION
## Summary
- 正規表現のリアルタイムマッチング・ハイライト表示機能を実装
- フラグトグル（g/i/m/s）、キャプチャグループ表示、プリセットパターン6種、置換プレビュー機能を追加
- コアロジックのユニットテスト（21件）とプリセット検証テストを追加

Closes #28

## Test plan
- [ ] `npm run test` — 全テスト通過を確認
- [ ] `npm run lint` — ESLintエラーなしを確認
- [ ] `npm run build` — ビルド成功を確認
- [ ] パターン入力でリアルタイムにマッチ箇所がハイライトされる
- [ ] フラグトグル（g/i/m/s）が正しく反映される
- [ ] プリセット選択でパターン・テスト文字列が一括設定される
- [ ] キャプチャグループ（番号・名前付き）が正しく表示される
- [ ] 置換文字列入力で置換結果がプレビューされる
- [ ] 無効な正規表現入力時にエラーメッセージが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)