### PR TITLE
feat: 割り勘計算機を追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, ArrowLeftRight, Braces, Clock, FileText, Fingerprint, FileDiff, Languages, Palette, Package, QrCode, Regex, Type, type LucideIcon } from "lucide-react";
+import { ArrowRight, ArrowLeftRight, Braces, Calculator, Clock, FileText, Fingerprint, FileDiff, Languages, Palette, Package, QrCode, Regex, Type, type LucideIcon } from "lucide-react";
 import {
   Card,
   CardHeader,
@@ -86,6 +86,12 @@ const tools: Tool[] = [
     description: "長さ・重さ・温度など各種単位を変換、計算式の表示",
     href: "/tools/unit-converter",
     icon: ArrowLeftRight,
+  },
+  {
+    name: "Split Bill Calculator",
+    description: "割り勘計算、端数処理、傾斜配分、税・サービス料の別計算",
+    href: "/tools/split-bill-calculator",
+    icon: Calculator,
   },
 ];
 

--- a/src/app/tools/split-bill-calculator/page.tsx
+++ b/src/app/tools/split-bill-calculator/page.tsx
@@ -1,0 +1,5 @@
+import { SplitBillCalculatorPage } from "@/features/split-bill-calculator/components/split-bill-calculator-page";
+
+export default function Page() {
+  return <SplitBillCalculatorPage />;
+}

--- a/src/features/split-bill-calculator/components/bill-items-section.tsx
+++ b/src/features/split-bill-calculator/components/bill-items-section.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { BillItem } from "../lib/types";
+
+type Props = {
+  items: BillItem[];
+  onAdd: () => void;
+  onRemove: (id: string) => void;
+  onUpdate: (id: string, field: "name" | "amount", value: string) => void;
+};
+
+export function BillItemsSection({ items, onAdd, onRemove, onUpdate }: Props) {
+  const showName = items.length > 1;
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <Label className="text-base font-semibold">金額</Label>
+        <Button variant="ghost" size="sm" onClick={onAdd}>
+          <Plus className="mr-1 h-4 w-4" />
+          項目追加
+        </Button>
+      </div>
+      <div className="space-y-2">
+        {items.map((item, index) => (
+          <div key={item.id} className="flex items-center gap-2">
+            {showName && (
+              <Input
+                placeholder={`項目${index + 1}`}
+                value={item.name}
+                onChange={(e) => onUpdate(item.id, "name", e.target.value)}
+                className="flex-1"
+              />
+            )}
+            <div className="relative flex-1">
+              <Input
+                type="number"
+                inputMode="numeric"
+                placeholder="0"
+                value={item.amount}
+                onChange={(e) => onUpdate(item.id, "amount", e.target.value)}
+                className="pr-8"
+                aria-label={showName ? `${item.name || `項目${index + 1}`}の金額` : "合計金額"}
+              />
+              <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+                円
+              </span>
+            </div>
+            {items.length > 1 && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => onRemove(item.id)}
+                aria-label={`${item.name || `項目${index + 1}`}を削除`}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/features/split-bill-calculator/components/bill-items-section.tsx
+++ b/src/features/split-bill-calculator/components/bill-items-section.tsx
@@ -34,12 +34,15 @@ export function BillItemsSection({ items, onAdd, onRemove, onUpdate }: Props) {
                 value={item.name}
                 onChange={(e) => onUpdate(item.id, "name", e.target.value)}
                 className="flex-1"
+                aria-label={`項目${index + 1}の名前`}
               />
             )}
             <div className="relative flex-1">
               <Input
                 type="number"
                 inputMode="numeric"
+                min={0}
+                step={1}
                 placeholder="0"
                 value={item.amount}
                 onChange={(e) => onUpdate(item.id, "amount", e.target.value)}

--- a/src/features/split-bill-calculator/components/options-section.tsx
+++ b/src/features/split-bill-calculator/components/options-section.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import type { BillOptions, RoundingMethod, RoundingUnit } from "../lib/types";
+
+type Props = {
+  options: BillOptions;
+  onUpdate: <K extends keyof BillOptions>(key: K, value: BillOptions[K]) => void;
+};
+
+const roundingMethods: { value: RoundingMethod; label: string }[] = [
+  { value: "ceil", label: "切り上げ" },
+  { value: "round", label: "四捨五入" },
+  { value: "floor", label: "切り捨て" },
+];
+
+const roundingUnits: { value: RoundingUnit; label: string }[] = [
+  { value: 1, label: "1円" },
+  { value: 10, label: "10円" },
+  { value: 100, label: "100円" },
+  { value: 500, label: "500円" },
+  { value: 1000, label: "1000円" },
+];
+
+export function OptionsSection({ options, onUpdate }: Props) {
+  return (
+    <section className="space-y-4">
+      <Label className="text-base font-semibold">オプション</Label>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="tax-rate" className="text-sm">税率</Label>
+          <div className="relative">
+            <Input
+              id="tax-rate"
+              type="number"
+              inputMode="decimal"
+              placeholder="0"
+              value={options.taxRate}
+              onChange={(e) => onUpdate("taxRate", e.target.value)}
+              className="pr-8"
+            />
+            <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+              %
+            </span>
+          </div>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="service-charge" className="text-sm">サービス料</Label>
+          <div className="relative">
+            <Input
+              id="service-charge"
+              type="number"
+              inputMode="decimal"
+              placeholder="0"
+              value={options.serviceChargeRate}
+              onChange={(e) => onUpdate("serviceChargeRate", e.target.value)}
+              className="pr-8"
+            />
+            <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+              %
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="text-sm">端数処理</Label>
+        <div className="flex gap-2" role="radiogroup" aria-label="端数処理の方法">
+          {roundingMethods.map((m) => (
+            <Button
+              key={m.value}
+              role="radio"
+              aria-checked={options.roundingMethod === m.value}
+              variant={options.roundingMethod === m.value ? "default" : "outline"}
+              size="sm"
+              onClick={() => onUpdate("roundingMethod", m.value)}
+              className="flex-1"
+            >
+              {m.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="text-sm">丸め単位</Label>
+        <div className="flex gap-2" role="radiogroup" aria-label="丸めの単位">
+          {roundingUnits.map((u) => (
+            <Button
+              key={u.value}
+              role="radio"
+              aria-checked={options.roundingUnit === u.value}
+              variant={options.roundingUnit === u.value ? "default" : "outline"}
+              size="sm"
+              onClick={() => onUpdate("roundingUnit", u.value)}
+              className={cn("flex-1")}
+            >
+              {u.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/split-bill-calculator/components/participants-section.tsx
+++ b/src/features/split-bill-calculator/components/participants-section.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { Participant } from "../lib/types";
+
+type Props = {
+  participants: Participant[];
+  onAdd: () => void;
+  onRemove: (id: string) => void;
+  onUpdate: (id: string, field: "name" | "ratio", value: string) => void;
+};
+
+export function ParticipantsSection({
+  participants,
+  onAdd,
+  onRemove,
+  onUpdate,
+}: Props) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <Label className="text-base font-semibold">参加者</Label>
+        <Button variant="ghost" size="sm" onClick={onAdd}>
+          <Plus className="mr-1 h-4 w-4" />
+          追加
+        </Button>
+      </div>
+      <div className="space-y-2">
+        {participants.map((p, index) => (
+          <div key={p.id} className="flex items-center gap-2">
+            <Input
+              placeholder={`参加者${index + 1}`}
+              value={p.name}
+              onChange={(e) => onUpdate(p.id, "name", e.target.value)}
+              className="flex-1"
+              aria-label={`参加者${index + 1}の名前`}
+            />
+            <div className="relative w-24">
+              <Input
+                type="number"
+                inputMode="decimal"
+                placeholder="1"
+                value={p.ratio}
+                onChange={(e) => onUpdate(p.id, "ratio", e.target.value)}
+                className="pr-8"
+                aria-label={`参加者${index + 1}の比率`}
+              />
+              <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+                倍
+              </span>
+            </div>
+            {participants.length > 1 && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => onRemove(p.id)}
+                aria-label={`${p.name || `参加者${index + 1}`}を削除`}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/features/split-bill-calculator/components/results-section.tsx
+++ b/src/features/split-bill-calculator/components/results-section.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import type { SplitResult } from "../lib/types";
+import { formatCurrency } from "../lib/calculator";
+
+type Props = {
+  result: SplitResult;
+};
+
+export function ResultsSection({ result }: Props) {
+  const showBreakdown =
+    result.taxAmount > 0 || result.serviceChargeAmount > 0;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">計算結果</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {showBreakdown && (
+          <div className="space-y-1 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">小計</span>
+              <span>{formatCurrency(result.subtotal)}円</span>
+            </div>
+            {result.taxAmount > 0 && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">税額</span>
+                <span>{formatCurrency(result.taxAmount)}円</span>
+              </div>
+            )}
+            {result.serviceChargeAmount > 0 && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">サービス料</span>
+                <span>{formatCurrency(result.serviceChargeAmount)}円</span>
+              </div>
+            )}
+            <Separator />
+            <div className="flex justify-between font-medium">
+              <span>合計</span>
+              <span>{formatCurrency(result.totalAmount)}円</span>
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-2">
+          {result.perPersonResults.map((pr) => (
+            <div
+              key={pr.participantId}
+              className="flex items-baseline justify-between"
+            >
+              <div className="flex items-baseline gap-2">
+                <span className="font-medium">{pr.name}</span>
+                {pr.ratio !== 1 && (
+                  <span className="text-xs text-muted-foreground">
+                    ({pr.ratio}倍)
+                  </span>
+                )}
+              </div>
+              <span className="text-lg font-bold tabular-nums">
+                {formatCurrency(pr.amount)}円
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {result.difference !== 0 && (
+          <>
+            <Separator />
+            <div className="text-xs text-muted-foreground">
+              <div className="flex justify-between">
+                <span>端数処理後の合計</span>
+                <span>{formatCurrency(result.adjustedTotal)}円</span>
+              </div>
+              <div className="flex justify-between">
+                <span>差額</span>
+                <span>
+                  {result.difference > 0 ? "+" : ""}
+                  {formatCurrency(result.difference)}円
+                </span>
+              </div>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/split-bill-calculator/components/split-bill-calculator-page.tsx
+++ b/src/features/split-bill-calculator/components/split-bill-calculator-page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Separator } from "@/components/ui/separator";
+import { useSplitBillCalculator } from "../lib/use-split-bill-calculator";
+import { BillItemsSection } from "./bill-items-section";
+import { OptionsSection } from "./options-section";
+import { ParticipantsSection } from "./participants-section";
+import { ResultsSection } from "./results-section";
+
+export function SplitBillCalculatorPage() {
+  const {
+    items,
+    participants,
+    options,
+    result,
+    addItem,
+    removeItem,
+    updateItem,
+    addParticipant,
+    removeParticipant,
+    updateParticipant,
+    updateOptions,
+  } = useSplitBillCalculator();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">
+          Split Bill Calculator
+        </h1>
+        <p className="mt-2 text-muted-foreground">
+          飲み会や食事の割り勘を計算。端数処理や傾斜配分にも対応。
+        </p>
+      </div>
+
+      <BillItemsSection
+        items={items}
+        onAdd={addItem}
+        onRemove={removeItem}
+        onUpdate={updateItem}
+      />
+
+      <Separator />
+
+      <OptionsSection options={options} onUpdate={updateOptions} />
+
+      <Separator />
+
+      <ParticipantsSection
+        participants={participants}
+        onAdd={addParticipant}
+        onRemove={removeParticipant}
+        onUpdate={updateParticipant}
+      />
+
+      <Separator />
+
+      {result && <ResultsSection result={result} />}
+    </div>
+  );
+}

--- a/src/features/split-bill-calculator/lib/__tests__/calculator.test.ts
+++ b/src/features/split-bill-calculator/lib/__tests__/calculator.test.ts
@@ -1,0 +1,242 @@
+import { roundAmount, formatCurrency, calculateSplit } from "../calculator";
+import type { BillItem, BillOptions, Participant } from "../types";
+
+describe("roundAmount", () => {
+  it("1円単位で四捨五入", () => {
+    expect(roundAmount(1234.5, "round", 1)).toBe(1235);
+    expect(roundAmount(1234.4, "round", 1)).toBe(1234);
+  });
+
+  it("10円単位で切り上げ", () => {
+    expect(roundAmount(1234, "ceil", 10)).toBe(1240);
+    expect(roundAmount(1230, "ceil", 10)).toBe(1230);
+  });
+
+  it("100円単位で切り捨て", () => {
+    expect(roundAmount(1299, "floor", 100)).toBe(1200);
+    expect(roundAmount(1300, "floor", 100)).toBe(1300);
+  });
+
+  it("10円単位で四捨五入", () => {
+    expect(roundAmount(1235, "round", 10)).toBe(1240);
+    expect(roundAmount(1234, "round", 10)).toBe(1230);
+  });
+
+  it("100円単位で切り上げ", () => {
+    expect(roundAmount(1201, "ceil", 100)).toBe(1300);
+    expect(roundAmount(1200, "ceil", 100)).toBe(1200);
+  });
+
+  it("1円単位で切り捨て", () => {
+    expect(roundAmount(1234.9, "floor", 1)).toBe(1234);
+  });
+
+  it("500円単位で切り上げ", () => {
+    expect(roundAmount(1234, "ceil", 500)).toBe(1500);
+    expect(roundAmount(1500, "ceil", 500)).toBe(1500);
+    expect(roundAmount(1501, "ceil", 500)).toBe(2000);
+  });
+
+  it("1000円単位で四捨五入", () => {
+    expect(roundAmount(1499, "round", 1000)).toBe(1000);
+    expect(roundAmount(1500, "round", 1000)).toBe(2000);
+    expect(roundAmount(2800, "round", 1000)).toBe(3000);
+  });
+
+  it("1000円単位で切り捨て", () => {
+    expect(roundAmount(1999, "floor", 1000)).toBe(1000);
+    expect(roundAmount(2000, "floor", 1000)).toBe(2000);
+  });
+});
+
+describe("formatCurrency", () => {
+  it("カンマ区切りでフォーマット", () => {
+    expect(formatCurrency(1000)).toBe("1,000");
+    expect(formatCurrency(12345678)).toBe("12,345,678");
+    expect(formatCurrency(0)).toBe("0");
+  });
+});
+
+describe("calculateSplit", () => {
+  const defaultOptions: BillOptions = {
+    taxRate: "0",
+    serviceChargeRate: "0",
+    roundingMethod: "round",
+    roundingUnit: 1,
+  };
+
+  function makeItems(...amounts: number[]): BillItem[] {
+    return amounts.map((a, i) => ({
+      id: `item-${i}`,
+      name: `Item ${i + 1}`,
+      amount: String(a),
+    }));
+  }
+
+  function makeParticipants(
+    ...configs: { name: string; ratio?: string }[]
+  ): Participant[] {
+    return configs.map((c, i) => ({
+      id: `p-${i}`,
+      name: c.name,
+      ratio: c.ratio ?? "1",
+    }));
+  }
+
+  it("均等割り（2人）", () => {
+    const result = calculateSplit(
+      makeItems(10000),
+      makeParticipants({ name: "A" }, { name: "B" }),
+      defaultOptions,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.subtotal).toBe(10000);
+    expect(result!.totalAmount).toBe(10000);
+    expect(result!.perPersonResults).toHaveLength(2);
+    expect(result!.perPersonResults[0].amount).toBe(5000);
+    expect(result!.perPersonResults[1].amount).toBe(5000);
+    expect(result!.difference).toBe(0);
+  });
+
+  it("均等割り（3人、端数あり・100円切り上げ）", () => {
+    const result = calculateSplit(
+      makeItems(10000),
+      makeParticipants({ name: "A" }, { name: "B" }, { name: "C" }),
+      { ...defaultOptions, roundingMethod: "ceil", roundingUnit: 100 },
+    );
+    expect(result).not.toBeNull();
+    // 10000 / 3 = 3333.33... → 切り上げ100円 = 3400
+    expect(result!.perPersonResults[0].amount).toBe(3400);
+    expect(result!.perPersonResults[1].amount).toBe(3400);
+    expect(result!.perPersonResults[2].amount).toBe(3400);
+    expect(result!.adjustedTotal).toBe(10200);
+    expect(result!.difference).toBe(200);
+  });
+
+  it("均等割り（3人、端数あり・100円切り捨て）", () => {
+    const result = calculateSplit(
+      makeItems(10000),
+      makeParticipants({ name: "A" }, { name: "B" }, { name: "C" }),
+      { ...defaultOptions, roundingMethod: "floor", roundingUnit: 100 },
+    );
+    expect(result).not.toBeNull();
+    // 10000 / 3 = 3333.33... → 切り捨て100円 = 3300
+    expect(result!.perPersonResults[0].amount).toBe(3300);
+    expect(result!.adjustedTotal).toBe(9900);
+    expect(result!.difference).toBe(-100);
+  });
+
+  it("傾斜配分（比率 2:1）", () => {
+    const result = calculateSplit(
+      makeItems(9000),
+      makeParticipants({ name: "幹事", ratio: "2" }, { name: "一般", ratio: "1" }),
+      defaultOptions,
+    );
+    expect(result).not.toBeNull();
+    // 9000 の 2:1 → 6000, 3000
+    expect(result!.perPersonResults[0].amount).toBe(6000);
+    expect(result!.perPersonResults[1].amount).toBe(3000);
+  });
+
+  it("傾斜配分（比率 1.5:1:0.7）", () => {
+    const result = calculateSplit(
+      makeItems(32000),
+      makeParticipants(
+        { name: "幹事", ratio: "1.5" },
+        { name: "一般", ratio: "1" },
+        { name: "学生", ratio: "0.7" },
+      ),
+      { ...defaultOptions, roundingUnit: 100, roundingMethod: "round" },
+    );
+    expect(result).not.toBeNull();
+    // totalRatio = 3.2, shares: 15000, 10000, 7000
+    expect(result!.perPersonResults[0].amount).toBe(15000);
+    expect(result!.perPersonResults[1].amount).toBe(10000);
+    expect(result!.perPersonResults[2].amount).toBe(7000);
+  });
+
+  it("税・サービス料の計算", () => {
+    const result = calculateSplit(
+      makeItems(10000),
+      makeParticipants({ name: "A" }, { name: "B" }),
+      { ...defaultOptions, taxRate: "10", serviceChargeRate: "10" },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.subtotal).toBe(10000);
+    expect(result!.taxAmount).toBe(1000);
+    expect(result!.serviceChargeAmount).toBe(1000);
+    expect(result!.totalAmount).toBe(12000);
+    expect(result!.perPersonResults[0].amount).toBe(6000);
+    expect(result!.perPersonResults[1].amount).toBe(6000);
+  });
+
+  it("複数項目の合算", () => {
+    const result = calculateSplit(
+      makeItems(5000, 3000, 2000),
+      makeParticipants({ name: "A" }, { name: "B" }),
+      defaultOptions,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.subtotal).toBe(10000);
+    expect(result!.perPersonResults[0].amount).toBe(5000);
+  });
+
+  it("参加者0人はnullを返す", () => {
+    const result = calculateSplit(makeItems(10000), [], defaultOptions);
+    expect(result).toBeNull();
+  });
+
+  it("金額0以下はnullを返す", () => {
+    const result = calculateSplit(
+      makeItems(0),
+      makeParticipants({ name: "A" }),
+      defaultOptions,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("1人の場合は全額", () => {
+    const result = calculateSplit(
+      makeItems(8500),
+      makeParticipants({ name: "A" }),
+      defaultOptions,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.perPersonResults[0].amount).toBe(8500);
+  });
+
+  it("不正な金額文字列は0として扱う", () => {
+    const items: BillItem[] = [
+      { id: "1", name: "有効", amount: "5000" },
+      { id: "2", name: "不正", amount: "abc" },
+    ];
+    const result = calculateSplit(
+      items,
+      makeParticipants({ name: "A" }),
+      defaultOptions,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.subtotal).toBe(5000);
+  });
+
+  it("不正な比率は1として扱う", () => {
+    const result = calculateSplit(
+      makeItems(10000),
+      makeParticipants({ name: "A", ratio: "abc" }, { name: "B", ratio: "1" }),
+      defaultOptions,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.perPersonResults[0].amount).toBe(5000);
+    expect(result!.perPersonResults[1].amount).toBe(5000);
+  });
+
+  it("名前が空の場合はデフォルト名を使用", () => {
+    const result = calculateSplit(
+      makeItems(10000),
+      [{ id: "p-0", name: "", ratio: "1" }],
+      defaultOptions,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.perPersonResults[0].name).toBe("参加者1");
+  });
+});

--- a/src/features/split-bill-calculator/lib/calculator.ts
+++ b/src/features/split-bill-calculator/lib/calculator.ts
@@ -1,0 +1,88 @@
+import type {
+  BillItem,
+  BillOptions,
+  Participant,
+  RoundingMethod,
+  RoundingUnit,
+  SplitResult,
+} from "./types";
+
+export function roundAmount(
+  amount: number,
+  method: RoundingMethod,
+  unit: RoundingUnit,
+): number {
+  const fn =
+    method === "ceil"
+      ? Math.ceil
+      : method === "floor"
+        ? Math.floor
+        : Math.round;
+  return fn(amount / unit) * unit;
+}
+
+export function formatCurrency(amount: number): string {
+  return amount.toLocaleString("ja-JP");
+}
+
+export function calculateSplit(
+  items: BillItem[],
+  participants: Participant[],
+  options: BillOptions,
+): SplitResult | null {
+  if (participants.length === 0) return null;
+
+  const subtotal = items.reduce((sum, item) => {
+    const val = parseFloat(item.amount);
+    return sum + (Number.isFinite(val) ? val : 0);
+  }, 0);
+
+  if (subtotal <= 0) return null;
+
+  const taxRate = parseFloat(options.taxRate) || 0;
+  const serviceChargeRate = parseFloat(options.serviceChargeRate) || 0;
+
+  const taxAmount = Math.round(subtotal * (taxRate / 100));
+  const serviceChargeAmount = Math.round(
+    subtotal * (serviceChargeRate / 100),
+  );
+  const totalAmount = subtotal + taxAmount + serviceChargeAmount;
+
+  const ratios = participants.map((p) => {
+    const r = parseFloat(p.ratio);
+    return Number.isFinite(r) && r > 0 ? r : 1;
+  });
+  const totalRatio = ratios.reduce((sum, r) => sum + r, 0);
+
+  const perPersonResults = participants.map((p, i) => {
+    const ratio = ratios[i];
+    const share = (totalAmount * ratio) / totalRatio;
+    const amount = roundAmount(
+      share,
+      options.roundingMethod,
+      options.roundingUnit,
+    );
+    return {
+      participantId: p.id,
+      name: p.name || `参加者${i + 1}`,
+      ratio,
+      amount,
+    };
+  });
+
+  const adjustedTotal = perPersonResults.reduce(
+    (sum, r) => sum + r.amount,
+    0,
+  );
+  const difference = adjustedTotal - totalAmount;
+
+  return {
+    subtotal,
+    taxAmount,
+    serviceChargeAmount,
+    totalAmount,
+    perPersonResults,
+    adjustedTotal,
+    difference,
+  };
+}

--- a/src/features/split-bill-calculator/lib/types.ts
+++ b/src/features/split-bill-calculator/lib/types.ts
@@ -1,0 +1,38 @@
+export type RoundingMethod = "ceil" | "floor" | "round";
+export type RoundingUnit = 1 | 10 | 100 | 500 | 1000;
+
+export type BillItem = {
+  id: string;
+  name: string;
+  amount: string;
+};
+
+export type Participant = {
+  id: string;
+  name: string;
+  ratio: string;
+};
+
+export type BillOptions = {
+  taxRate: string;
+  serviceChargeRate: string;
+  roundingMethod: RoundingMethod;
+  roundingUnit: RoundingUnit;
+};
+
+export type PerPersonResult = {
+  participantId: string;
+  name: string;
+  ratio: number;
+  amount: number;
+};
+
+export type SplitResult = {
+  subtotal: number;
+  taxAmount: number;
+  serviceChargeAmount: number;
+  totalAmount: number;
+  perPersonResults: PerPersonResult[];
+  adjustedTotal: number;
+  difference: number;
+};

--- a/src/features/split-bill-calculator/lib/use-split-bill-calculator.ts
+++ b/src/features/split-bill-calculator/lib/use-split-bill-calculator.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState, useMemo, useCallback } from "react";
+import type { BillItem, BillOptions, Participant, SplitResult } from "./types";
+import { calculateSplit } from "./calculator";
+
+let nextItemId = 1;
+let nextParticipantId = 1;
+
+function createItem(name = "", amount = ""): BillItem {
+  return { id: `item-${nextItemId++}`, name, amount };
+}
+
+function createParticipant(name = "", ratio = "1"): Participant {
+  return { id: `p-${nextParticipantId++}`, name, ratio };
+}
+
+const defaultOptions: BillOptions = {
+  taxRate: "0",
+  serviceChargeRate: "0",
+  roundingMethod: "round",
+  roundingUnit: 100,
+};
+
+export function useSplitBillCalculator() {
+  const [items, setItems] = useState<BillItem[]>([createItem()]);
+  const [participants, setParticipants] = useState<Participant[]>([
+    createParticipant(),
+    createParticipant(),
+  ]);
+  const [options, setOptions] = useState<BillOptions>(defaultOptions);
+
+  const addItem = useCallback(() => {
+    setItems((prev) => [...prev, createItem()]);
+  }, []);
+
+  const removeItem = useCallback((id: string) => {
+    setItems((prev) => (prev.length > 1 ? prev.filter((i) => i.id !== id) : prev));
+  }, []);
+
+  const updateItem = useCallback(
+    (id: string, field: "name" | "amount", value: string) => {
+      setItems((prev) =>
+        prev.map((i) => (i.id === id ? { ...i, [field]: value } : i)),
+      );
+    },
+    [],
+  );
+
+  const addParticipant = useCallback(() => {
+    setParticipants((prev) => [...prev, createParticipant()]);
+  }, []);
+
+  const removeParticipant = useCallback((id: string) => {
+    setParticipants((prev) =>
+      prev.length > 1 ? prev.filter((p) => p.id !== id) : prev,
+    );
+  }, []);
+
+  const updateParticipant = useCallback(
+    (id: string, field: "name" | "ratio", value: string) => {
+      setParticipants((prev) =>
+        prev.map((p) => (p.id === id ? { ...p, [field]: value } : p)),
+      );
+    },
+    [],
+  );
+
+  const updateOptions = useCallback(
+    <K extends keyof BillOptions>(key: K, value: BillOptions[K]) => {
+      setOptions((prev) => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+
+  const result: SplitResult | null = useMemo(
+    () => calculateSplit(items, participants, options),
+    [items, participants, options],
+  );
+
+  return {
+    items,
+    participants,
+    options,
+    result,
+    addItem,
+    removeItem,
+    updateItem,
+    addParticipant,
+    removeParticipant,
+    updateParticipant,
+    updateOptions,
+  };
+}


### PR DESCRIPTION
## Summary
- 割り勘計算機ツールを新規追加
- 均等割り・傾斜配分（比率設定）・端数処理（切り上げ/四捨五入/切り捨て × 1〜1000円単位）に対応
- 税・サービス料の別計算オプション、複数項目の分離入力に対応
- 計算ロジックのユニットテスト23件を追加

Closes #32

## Test plan
- [ ] `npm run build` がエラーなく完了すること
- [ ] `npm run lint` がエラーなく完了すること
- [ ] `npm run test` が全テストパスすること
- [ ] `/tools/split-bill-calculator` で均等割りが正しく計算されること
- [ ] 端数処理の切り替え（方法・単位）が結果に反映されること
- [ ] 参加者の追加/削除/比率変更が動作すること
- [ ] 税率・サービス料の入力が合計に反映されること
- [ ] 複数項目の追加/削除が動作し、合算されること
- [ ] 差額が発生する場合に注記が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)