### PR TITLE
feat: タイマー / ストップウォッチツールを追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, ArrowLeftRight, Braces, Calculator, Clock, FileText, Fingerprint, FileDiff, Languages, Palette, Package, QrCode, Regex, Type, type LucideIcon } from "lucide-react";
+import { ArrowRight, ArrowLeftRight, Braces, Calculator, Clock, FileText, Fingerprint, FileDiff, Languages, Palette, Package, QrCode, Regex, Timer, Type, type LucideIcon } from "lucide-react";
 import {
   Card,
   CardHeader,
@@ -92,6 +92,12 @@ const tools: Tool[] = [
     description: "割り勘計算、端数処理、傾斜配分、税・サービス料の別計算",
     href: "/tools/split-bill-calculator",
     icon: Calculator,
+  },
+  {
+    name: "Timer / Stopwatch",
+    description: "カウントダウンタイマー・ストップウォッチ、プリセット・複数同時実行・ブラウザ通知",
+    href: "/tools/timer-stopwatch",
+    icon: Timer,
   },
 ];
 

--- a/src/app/tools/timer-stopwatch/page.tsx
+++ b/src/app/tools/timer-stopwatch/page.tsx
@@ -1,0 +1,5 @@
+import { TimerStopwatchPage } from "@/features/timer-stopwatch/components/timer-stopwatch-page";
+
+export default function Page() {
+  return <TimerStopwatchPage />;
+}

--- a/src/app/tools/timer-stopwatch/page.tsx
+++ b/src/app/tools/timer-stopwatch/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from "next";
 import { TimerStopwatchPage } from "@/features/timer-stopwatch/components/timer-stopwatch-page";
+
+export const metadata: Metadata = {
+  title: "Timer / Stopwatch - Personal Tools",
+  description: "複数タイマーの同時計測と、ラップ記録付きストップウォッチ",
+};
 
 export default function Page() {
   return <TimerStopwatchPage />;

--- a/src/features/timer-stopwatch/components/preset-buttons.tsx
+++ b/src/features/timer-stopwatch/components/preset-buttons.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+
+type Props = {
+  onSelect: (title: string, durationMs: number) => void;
+};
+
+const presets: { label: string; title: string; durationMs: number }[] = [
+  { label: "5分", title: "5分タイマー", durationMs: 5 * 60_000 },
+  { label: "10分", title: "10分タイマー", durationMs: 10 * 60_000 },
+  { label: "25分 (ポモドーロ)", title: "ポモドーロ", durationMs: 25 * 60_000 },
+];
+
+export function PresetButtons({ onSelect }: Props) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-sm">プリセット</Label>
+      <div className="flex flex-wrap gap-2">
+        {presets.map((p) => (
+          <Button
+            key={p.label}
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onSelect(p.title, p.durationMs)}
+          >
+            {p.label}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/timer-stopwatch/components/stopwatch-section.tsx
+++ b/src/features/timer-stopwatch/components/stopwatch-section.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { Flag, Pause, Play, RotateCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { formatStopwatch } from "../lib/format-time";
+import { getElapsed } from "../lib/stopwatch-engine";
+import type { Stopwatch } from "../lib/types";
+import { useNow } from "../lib/use-now";
+
+type Props = {
+  stopwatch: Stopwatch;
+  onStart: () => void;
+  onPause: () => void;
+  onReset: () => void;
+  onLap: () => void;
+};
+
+export function StopwatchSection({
+  stopwatch,
+  onStart,
+  onPause,
+  onReset,
+  onLap,
+}: Props) {
+  const now = useNow(50, stopwatch.status === "running");
+  const elapsed = getElapsed(stopwatch, now);
+  const isRunning = stopwatch.status === "running";
+
+  return (
+    <section className="space-y-4">
+      <Label className="text-base font-semibold">ストップウォッチ</Label>
+
+      <Card>
+        <CardContent className="space-y-4 p-4">
+          <div
+            className="text-center font-mono text-5xl tabular-nums"
+            aria-label={`経過 ${formatStopwatch(elapsed)}`}
+          >
+            {formatStopwatch(elapsed)}
+          </div>
+
+          <div className="flex flex-wrap justify-center gap-2">
+            {isRunning ? (
+              <Button type="button" variant="outline" onClick={onPause}>
+                <Pause className="h-4 w-4" aria-hidden="true" />
+                一時停止
+              </Button>
+            ) : (
+              <Button type="button" onClick={onStart}>
+                <Play className="h-4 w-4" aria-hidden="true" />
+                {stopwatch.accumulatedMs > 0 ? "再開" : "開始"}
+              </Button>
+            )}
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onLap}
+              disabled={!isRunning}
+            >
+              <Flag className="h-4 w-4" aria-hidden="true" />
+              ラップ
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onReset}
+              disabled={stopwatch.status === "idle"}
+            >
+              <RotateCcw className="h-4 w-4" aria-hidden="true" />
+              リセット
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {stopwatch.laps.length > 0 && (
+        <div className="space-y-2">
+          <Label className="text-sm">ラップ</Label>
+          <ol className="space-y-1 rounded-lg border p-3 text-sm">
+            {stopwatch.laps
+              .map((lap, index) => ({ lap, index }))
+              .reverse()
+              .map(({ lap, index }) => (
+                <li
+                  key={lap.id}
+                  className="grid grid-cols-[auto_1fr_1fr] gap-3 font-mono tabular-nums"
+                >
+                  <span className="text-muted-foreground">#{index + 1}</span>
+                  <span className="text-right">
+                    <span className="mr-2 text-xs text-muted-foreground">
+                      split
+                    </span>
+                    {formatStopwatch(lap.splitMs)}
+                  </span>
+                  <span className="text-right">
+                    <span className="mr-2 text-xs text-muted-foreground">
+                      total
+                    </span>
+                    {formatStopwatch(lap.totalMs)}
+                  </span>
+                </li>
+              ))}
+          </ol>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/features/timer-stopwatch/components/timer-card.tsx
+++ b/src/features/timer-stopwatch/components/timer-card.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { Pause, Play, RotateCcw, Trash2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { getDisplayRemaining } from "../lib/timer-engine";
+import type { Timer } from "../lib/types";
+import { formatTimer } from "../lib/format-time";
+import { useNow } from "../lib/use-now";
+
+type Props = {
+  timer: Timer;
+  onStart: (id: string) => void;
+  onPause: (id: string) => void;
+  onReset: (id: string) => void;
+  onRemove: (id: string) => void;
+};
+
+export function TimerCard({ timer, onStart, onPause, onReset, onRemove }: Props) {
+  const now = useNow(100, timer.status === "running");
+  const remaining = getDisplayRemaining(timer, now);
+  const isRunning = timer.status === "running";
+  const isCompleted = timer.status === "completed";
+
+  return (
+    <Card
+      className={cn(
+        "transition-colors",
+        isCompleted && "border-primary bg-primary/5",
+      )}
+    >
+      <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex-1 space-y-1">
+          <div className="flex items-center gap-2">
+            <span className="font-medium">{timer.title}</span>
+            {isCompleted && <Badge variant="default">終了</Badge>}
+          </div>
+          <div
+            className={cn(
+              "font-mono text-3xl tabular-nums",
+              isCompleted && "text-primary",
+            )}
+            aria-label={`残り ${formatTimer(remaining)}`}
+          >
+            {formatTimer(remaining)}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {isRunning ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => onPause(timer.id)}
+              aria-label="一時停止"
+            >
+              <Pause className="h-4 w-4" aria-hidden="true" />
+              一時停止
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => onStart(timer.id)}
+              disabled={isCompleted}
+              aria-label="開始"
+            >
+              <Play className="h-4 w-4" aria-hidden="true" />
+              開始
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onReset(timer.id)}
+            aria-label="リセット"
+          >
+            <RotateCcw className="h-4 w-4" aria-hidden="true" />
+            リセット
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => onRemove(timer.id)}
+            aria-label="削除"
+          >
+            <Trash2 className="h-4 w-4" aria-hidden="true" />
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/timer-stopwatch/components/timer-section.tsx
+++ b/src/features/timer-stopwatch/components/timer-section.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { Timer } from "../lib/types";
+import { PresetButtons } from "./preset-buttons";
+import { TimerCard } from "./timer-card";
+
+type Props = {
+  timers: Timer[];
+  onAdd: (title: string, durationMs: number) => void;
+  onStart: (id: string) => void;
+  onPause: (id: string) => void;
+  onReset: (id: string) => void;
+  onRemove: (id: string) => void;
+};
+
+export function TimerSection({
+  timers,
+  onAdd,
+  onStart,
+  onPause,
+  onReset,
+  onRemove,
+}: Props) {
+  const [title, setTitle] = useState("");
+  const [minutes, setMinutes] = useState("5");
+  const [seconds, setSeconds] = useState("0");
+
+  const handleAddCustom = () => {
+    const mins = Number.parseInt(minutes, 10);
+    const secs = Number.parseInt(seconds, 10);
+    const totalMs =
+      (Number.isFinite(mins) ? Math.max(0, mins) : 0) * 60_000 +
+      (Number.isFinite(secs) ? Math.max(0, secs) : 0) * 1_000;
+    if (totalMs <= 0) return;
+    onAdd(title, totalMs);
+    setTitle("");
+  };
+
+  return (
+    <section className="space-y-4">
+      <Label className="text-base font-semibold">タイマー</Label>
+
+      <div className="space-y-3 rounded-lg border p-4">
+        <PresetButtons onSelect={(t, d) => onAdd(t, d)} />
+
+        <div className="space-y-1.5">
+          <Label htmlFor="timer-title" className="text-sm">
+            タイトル（任意）
+          </Label>
+          <Input
+            id="timer-title"
+            placeholder="例: 洗濯 / パスタ茹で"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="timer-minutes" className="text-sm">
+              分
+            </Label>
+            <Input
+              id="timer-minutes"
+              type="number"
+              inputMode="numeric"
+              min={0}
+              value={minutes}
+              onChange={(e) => setMinutes(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="timer-seconds" className="text-sm">
+              秒
+            </Label>
+            <Input
+              id="timer-seconds"
+              type="number"
+              inputMode="numeric"
+              min={0}
+              max={59}
+              value={seconds}
+              onChange={(e) => setSeconds(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <Button type="button" onClick={handleAddCustom} className="w-full">
+          <Plus className="h-4 w-4" aria-hidden="true" />
+          タイマーを追加
+        </Button>
+      </div>
+
+      {timers.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          タイマーを追加すると、ここに表示されます。
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {timers.map((timer) => (
+            <TimerCard
+              key={timer.id}
+              timer={timer}
+              onStart={onStart}
+              onPause={onPause}
+              onReset={onReset}
+              onRemove={onRemove}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/features/timer-stopwatch/components/timer-stopwatch-page.tsx
+++ b/src/features/timer-stopwatch/components/timer-stopwatch-page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useStopwatch } from "../lib/use-stopwatch";
+import { useTimers } from "../lib/use-timers";
+import { StopwatchSection } from "./stopwatch-section";
+import { TimerSection } from "./timer-section";
+
+export function TimerStopwatchPage() {
+  const timers = useTimers();
+  const stopwatch = useStopwatch();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Timer / Stopwatch</h1>
+        <p className="mt-2 text-muted-foreground">
+          カウントダウンタイマーとストップウォッチ。プリセット・複数同時実行・ブラウザ通知対応。
+        </p>
+      </div>
+
+      <Tabs defaultValue="timer">
+        <TabsList className="w-full sm:w-auto">
+          <TabsTrigger value="timer">タイマー</TabsTrigger>
+          <TabsTrigger value="stopwatch">ストップウォッチ</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="timer" className="mt-4">
+          <TimerSection
+            timers={timers.timers}
+            onAdd={timers.addTimer}
+            onStart={timers.start}
+            onPause={timers.pause}
+            onReset={timers.reset}
+            onRemove={timers.remove}
+          />
+        </TabsContent>
+
+        <TabsContent value="stopwatch" className="mt-4">
+          <StopwatchSection
+            stopwatch={stopwatch.stopwatch}
+            onStart={stopwatch.start}
+            onPause={stopwatch.pause}
+            onReset={stopwatch.reset}
+            onLap={stopwatch.lap}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/features/timer-stopwatch/lib/__tests__/format-time.test.ts
+++ b/src/features/timer-stopwatch/lib/__tests__/format-time.test.ts
@@ -1,0 +1,41 @@
+import { formatTimer, formatStopwatch } from "../format-time";
+
+describe("formatTimer", () => {
+  it("残り時間を MM:SS 形式で表示", () => {
+    expect(formatTimer(0)).toBe("00:00");
+    expect(formatTimer(1_000)).toBe("00:01");
+    expect(formatTimer(61_000)).toBe("01:01");
+    expect(formatTimer(599_000)).toBe("09:59");
+  });
+
+  it("1時間以上は HH:MM:SS 形式で表示", () => {
+    expect(formatTimer(3_600_000)).toBe("01:00:00");
+    expect(formatTimer(3_661_000)).toBe("01:01:01");
+  });
+
+  it("負の値は 00:00 で表示", () => {
+    expect(formatTimer(-500)).toBe("00:00");
+  });
+
+  it("端数ミリ秒は切り上げ（残り時間の直感に合わせる）", () => {
+    expect(formatTimer(500)).toBe("00:01");
+    expect(formatTimer(1)).toBe("00:01");
+  });
+});
+
+describe("formatStopwatch", () => {
+  it("MM:SS.mm 形式で表示", () => {
+    expect(formatStopwatch(0)).toBe("00:00.00");
+    expect(formatStopwatch(1_234)).toBe("00:01.23");
+    expect(formatStopwatch(60_999)).toBe("01:00.99");
+  });
+
+  it("1時間以上は HH:MM:SS.mm 形式で表示", () => {
+    expect(formatStopwatch(3_600_000)).toBe("01:00:00.00");
+    expect(formatStopwatch(3_661_120)).toBe("01:01:01.12");
+  });
+
+  it("負の値は 00:00.00 で表示", () => {
+    expect(formatStopwatch(-1)).toBe("00:00.00");
+  });
+});

--- a/src/features/timer-stopwatch/lib/__tests__/stopwatch-engine.test.ts
+++ b/src/features/timer-stopwatch/lib/__tests__/stopwatch-engine.test.ts
@@ -1,0 +1,94 @@
+import {
+  createStopwatch,
+  startStopwatch,
+  pauseStopwatch,
+  resetStopwatch,
+  getElapsed,
+  recordLap,
+} from "../stopwatch-engine";
+
+describe("createStopwatch", () => {
+  it("idle 状態で初期化される", () => {
+    const sw = createStopwatch();
+    expect(sw).toEqual({
+      status: "idle",
+      accumulatedMs: 0,
+      startedAt: null,
+      laps: [],
+    });
+  });
+});
+
+describe("startStopwatch", () => {
+  it("idle から running に遷移し startedAt が設定される", () => {
+    const started = startStopwatch(createStopwatch(), 1_000);
+    expect(started.status).toBe("running");
+    expect(started.startedAt).toBe(1_000);
+  });
+
+  it("running 中は変更されない", () => {
+    const running = startStopwatch(createStopwatch(), 1_000);
+    expect(startStopwatch(running, 2_000)).toBe(running);
+  });
+});
+
+describe("pauseStopwatch", () => {
+  it("running から paused に遷移し accumulatedMs を加算", () => {
+    const running = startStopwatch(createStopwatch(), 1_000);
+    const paused = pauseStopwatch(running, 6_000);
+    expect(paused.status).toBe("paused");
+    expect(paused.accumulatedMs).toBe(5_000);
+    expect(paused.startedAt).toBeNull();
+  });
+
+  it("paused から再度 start / pause すると累積経過が維持される", () => {
+    const sw = startStopwatch(createStopwatch(), 1_000);
+    const paused = pauseStopwatch(sw, 6_000);
+    const restarted = startStopwatch(paused, 10_000);
+    const pausedAgain = pauseStopwatch(restarted, 13_000);
+    expect(pausedAgain.accumulatedMs).toBe(8_000);
+  });
+
+  it("running 以外は変更されない", () => {
+    const sw = createStopwatch();
+    expect(pauseStopwatch(sw, 1_000)).toBe(sw);
+  });
+});
+
+describe("resetStopwatch", () => {
+  it("初期状態に戻る", () => {
+    expect(resetStopwatch()).toEqual(createStopwatch());
+  });
+});
+
+describe("getElapsed", () => {
+  it("running 中は accumulated + (now - startedAt)", () => {
+    const running = startStopwatch(createStopwatch(), 1_000);
+    expect(getElapsed(running, 6_000)).toBe(5_000);
+  });
+
+  it("paused は accumulatedMs を返す", () => {
+    const running = startStopwatch(createStopwatch(), 1_000);
+    const paused = pauseStopwatch(running, 6_000);
+    expect(getElapsed(paused, 999_999)).toBe(5_000);
+  });
+});
+
+describe("recordLap", () => {
+  it("ラップ毎に total と split を記録", () => {
+    const sw = startStopwatch(createStopwatch(), 0);
+    const lap1 = recordLap(sw, 3_000, "l1");
+    expect(lap1.laps).toEqual([{ id: "l1", totalMs: 3_000, splitMs: 3_000 }]);
+
+    const lap2 = recordLap(lap1, 8_000, "l2");
+    expect(lap2.laps).toEqual([
+      { id: "l1", totalMs: 3_000, splitMs: 3_000 },
+      { id: "l2", totalMs: 8_000, splitMs: 5_000 },
+    ]);
+  });
+
+  it("running でないときはラップを追加しない", () => {
+    const sw = createStopwatch();
+    expect(recordLap(sw, 1_000, "l1")).toBe(sw);
+  });
+});

--- a/src/features/timer-stopwatch/lib/__tests__/timer-engine.test.ts
+++ b/src/features/timer-stopwatch/lib/__tests__/timer-engine.test.ts
@@ -1,0 +1,125 @@
+import {
+  createTimer,
+  startTimer,
+  pauseTimer,
+  resetTimer,
+  tickTimer,
+  getDisplayRemaining,
+} from "../timer-engine";
+
+describe("createTimer", () => {
+  it("idle 状態で初期化される", () => {
+    const timer = createTimer("t1", "Laundry", 60_000);
+    expect(timer).toMatchObject({
+      id: "t1",
+      title: "Laundry",
+      durationMs: 60_000,
+      remainingMs: 60_000,
+      endsAt: null,
+      status: "idle",
+    });
+  });
+});
+
+describe("startTimer", () => {
+  it("idle から running に遷移し endsAt が設定される", () => {
+    const timer = createTimer("t1", "Laundry", 60_000);
+    const started = startTimer(timer, 1_000);
+    expect(started.status).toBe("running");
+    expect(started.endsAt).toBe(61_000);
+  });
+
+  it("running 中は変更されない", () => {
+    const timer = createTimer("t1", "x", 60_000);
+    const running = startTimer(timer, 1_000);
+    const again = startTimer(running, 2_000);
+    expect(again).toBe(running);
+  });
+
+  it("残り 0 の completed タイマーはスタートしない", () => {
+    const completed = { ...createTimer("t1", "x", 60_000), remainingMs: 0 };
+    expect(startTimer(completed, 1_000)).toBe(completed);
+  });
+});
+
+describe("pauseTimer", () => {
+  it("running から paused に遷移し remainingMs を計算", () => {
+    const timer = createTimer("t1", "x", 60_000);
+    const running = startTimer(timer, 1_000);
+    const paused = pauseTimer(running, 21_000);
+    expect(paused.status).toBe("paused");
+    expect(paused.remainingMs).toBe(40_000);
+    expect(paused.endsAt).toBeNull();
+  });
+
+  it("running 以外のタイマーは変更されない", () => {
+    const timer = createTimer("t1", "x", 60_000);
+    expect(pauseTimer(timer, 1_000)).toBe(timer);
+  });
+
+  it("終了時刻を過ぎていたら remainingMs は 0", () => {
+    const timer = createTimer("t1", "x", 60_000);
+    const running = startTimer(timer, 1_000);
+    const paused = pauseTimer(running, 999_999);
+    expect(paused.remainingMs).toBe(0);
+  });
+});
+
+describe("resetTimer", () => {
+  it("duration に戻し idle にする", () => {
+    const timer = createTimer("t1", "x", 60_000);
+    const running = startTimer(timer, 1_000);
+    const reset = resetTimer(running);
+    expect(reset.status).toBe("idle");
+    expect(reset.remainingMs).toBe(60_000);
+    expect(reset.endsAt).toBeNull();
+  });
+});
+
+describe("tickTimer", () => {
+  it("running 中で endsAt 未到達なら状態変化なし", () => {
+    const timer = createTimer("t1", "x", 60_000);
+    const running = startTimer(timer, 1_000);
+    const result = tickTimer(running, 30_000);
+    expect(result.justCompleted).toBe(false);
+    expect(result.timer).toBe(running);
+  });
+
+  it("running 中で endsAt 到達時に completed へ遷移し justCompleted が true", () => {
+    const timer = createTimer("t1", "x", 60_000);
+    const running = startTimer(timer, 1_000);
+    const result = tickTimer(running, 61_000);
+    expect(result.justCompleted).toBe(true);
+    expect(result.timer.status).toBe("completed");
+    expect(result.timer.remainingMs).toBe(0);
+    expect(result.timer.endsAt).toBeNull();
+  });
+
+  it("running 以外は変化しない", () => {
+    const timer = createTimer("t1", "x", 60_000);
+    const result = tickTimer(timer, 999_999);
+    expect(result.justCompleted).toBe(false);
+    expect(result.timer).toBe(timer);
+  });
+});
+
+describe("getDisplayRemaining", () => {
+  it("running 中は endsAt - now を返す", () => {
+    const timer = createTimer("t1", "x", 60_000);
+    const running = startTimer(timer, 1_000);
+    expect(getDisplayRemaining(running, 21_000)).toBe(40_000);
+  });
+
+  it("paused は remainingMs を返す", () => {
+    const timer = createTimer("t1", "x", 60_000);
+    const running = startTimer(timer, 1_000);
+    const paused = pauseTimer(running, 21_000);
+    expect(getDisplayRemaining(paused, 999_999)).toBe(40_000);
+  });
+
+  it("running で endsAt 超過時は 0 を返す", () => {
+    const timer = createTimer("t1", "x", 60_000);
+    const running = startTimer(timer, 1_000);
+    expect(getDisplayRemaining(running, 999_999)).toBe(0);
+  });
+});

--- a/src/features/timer-stopwatch/lib/format-time.ts
+++ b/src/features/timer-stopwatch/lib/format-time.ts
@@ -1,0 +1,30 @@
+function pad(value: number, length: number): string {
+  return value.toString().padStart(length, "0");
+}
+
+export function formatTimer(ms: number): string {
+  const clamped = Math.max(0, Math.ceil(ms / 1000));
+  const hours = Math.floor(clamped / 3600);
+  const minutes = Math.floor((clamped % 3600) / 60);
+  const seconds = clamped % 60;
+
+  if (hours > 0) {
+    return `${pad(hours, 2)}:${pad(minutes, 2)}:${pad(seconds, 2)}`;
+  }
+  return `${pad(minutes, 2)}:${pad(seconds, 2)}`;
+}
+
+export function formatStopwatch(ms: number): string {
+  const clamped = Math.max(0, Math.floor(ms));
+  const totalSeconds = Math.floor(clamped / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const centis = Math.floor((clamped % 1000) / 10);
+
+  const base = `${pad(minutes, 2)}:${pad(seconds, 2)}.${pad(centis, 2)}`;
+  if (hours > 0) {
+    return `${pad(hours, 2)}:${base}`;
+  }
+  return base;
+}

--- a/src/features/timer-stopwatch/lib/notifications.ts
+++ b/src/features/timer-stopwatch/lib/notifications.ts
@@ -1,0 +1,63 @@
+type WindowWithWebkitAudio = Window & {
+  webkitAudioContext?: typeof AudioContext;
+};
+
+export function isNotificationSupported(): boolean {
+  return typeof window !== "undefined" && "Notification" in window;
+}
+
+export async function ensureNotificationPermission(): Promise<NotificationPermission> {
+  if (!isNotificationSupported()) {
+    return "denied";
+  }
+  if (Notification.permission === "default") {
+    try {
+      return await Notification.requestPermission();
+    } catch {
+      return "denied";
+    }
+  }
+  return Notification.permission;
+}
+
+export function playBeep(): void {
+  if (typeof window === "undefined") return;
+  const AudioCtx =
+    window.AudioContext ?? (window as WindowWithWebkitAudio).webkitAudioContext;
+  if (!AudioCtx) return;
+
+  try {
+    const ctx = new AudioCtx();
+    const oscillator = ctx.createOscillator();
+    const gain = ctx.createGain();
+    oscillator.type = "sine";
+    oscillator.frequency.value = 880;
+    gain.gain.setValueAtTime(0, ctx.currentTime);
+    gain.gain.linearRampToValueAtTime(0.25, ctx.currentTime + 0.01);
+    gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.6);
+    oscillator.connect(gain);
+    gain.connect(ctx.destination);
+    oscillator.start();
+    oscillator.stop(ctx.currentTime + 0.6);
+    oscillator.onended = () => {
+      ctx.close().catch(() => {});
+    };
+  } catch {
+    // Audio context issues should not break the app.
+  }
+}
+
+export function notifyTimerDone(title: string): void {
+  playBeep();
+  if (!isNotificationSupported() || Notification.permission !== "granted") {
+    return;
+  }
+  try {
+    new Notification("タイマー終了", {
+      body: title || "タイマーが終了しました",
+      silent: false,
+    });
+  } catch {
+    // Ignore notification failures.
+  }
+}

--- a/src/features/timer-stopwatch/lib/stopwatch-engine.ts
+++ b/src/features/timer-stopwatch/lib/stopwatch-engine.ts
@@ -1,0 +1,57 @@
+import type { Stopwatch } from "./types";
+
+export function createStopwatch(): Stopwatch {
+  return {
+    status: "idle",
+    accumulatedMs: 0,
+    startedAt: null,
+    laps: [],
+  };
+}
+
+export function startStopwatch(sw: Stopwatch, now: number): Stopwatch {
+  if (sw.status === "running") {
+    return sw;
+  }
+  return {
+    ...sw,
+    status: "running",
+    startedAt: now,
+  };
+}
+
+export function pauseStopwatch(sw: Stopwatch, now: number): Stopwatch {
+  if (sw.status !== "running" || sw.startedAt === null) {
+    return sw;
+  }
+  return {
+    ...sw,
+    status: "paused",
+    accumulatedMs: sw.accumulatedMs + (now - sw.startedAt),
+    startedAt: null,
+  };
+}
+
+export function resetStopwatch(): Stopwatch {
+  return createStopwatch();
+}
+
+export function getElapsed(sw: Stopwatch, now: number): number {
+  if (sw.status === "running" && sw.startedAt !== null) {
+    return sw.accumulatedMs + (now - sw.startedAt);
+  }
+  return sw.accumulatedMs;
+}
+
+export function recordLap(sw: Stopwatch, now: number, lapId: string): Stopwatch {
+  if (sw.status !== "running") {
+    return sw;
+  }
+  const totalMs = getElapsed(sw, now);
+  const prevTotal = sw.laps.length > 0 ? sw.laps[sw.laps.length - 1].totalMs : 0;
+  const splitMs = totalMs - prevTotal;
+  return {
+    ...sw,
+    laps: [...sw.laps, { id: lapId, totalMs, splitMs }],
+  };
+}

--- a/src/features/timer-stopwatch/lib/timer-engine.ts
+++ b/src/features/timer-stopwatch/lib/timer-engine.ts
@@ -1,0 +1,76 @@
+import type { Timer } from "./types";
+
+export function createTimer(
+  id: string,
+  title: string,
+  durationMs: number,
+): Timer {
+  return {
+    id,
+    title,
+    durationMs,
+    remainingMs: durationMs,
+    endsAt: null,
+    status: "idle",
+  };
+}
+
+export function startTimer(timer: Timer, now: number): Timer {
+  if (timer.status === "running" || timer.remainingMs <= 0) {
+    return timer;
+  }
+  return {
+    ...timer,
+    status: "running",
+    endsAt: now + timer.remainingMs,
+  };
+}
+
+export function pauseTimer(timer: Timer, now: number): Timer {
+  if (timer.status !== "running" || timer.endsAt === null) {
+    return timer;
+  }
+  return {
+    ...timer,
+    status: "paused",
+    remainingMs: Math.max(0, timer.endsAt - now),
+    endsAt: null,
+  };
+}
+
+export function resetTimer(timer: Timer): Timer {
+  return {
+    ...timer,
+    status: "idle",
+    remainingMs: timer.durationMs,
+    endsAt: null,
+  };
+}
+
+export function tickTimer(
+  timer: Timer,
+  now: number,
+): { timer: Timer; justCompleted: boolean } {
+  if (timer.status !== "running" || timer.endsAt === null) {
+    return { timer, justCompleted: false };
+  }
+  if (now >= timer.endsAt) {
+    return {
+      timer: {
+        ...timer,
+        status: "completed",
+        remainingMs: 0,
+        endsAt: null,
+      },
+      justCompleted: true,
+    };
+  }
+  return { timer, justCompleted: false };
+}
+
+export function getDisplayRemaining(timer: Timer, now: number): number {
+  if (timer.status === "running" && timer.endsAt !== null) {
+    return Math.max(0, timer.endsAt - now);
+  }
+  return timer.remainingMs;
+}

--- a/src/features/timer-stopwatch/lib/types.ts
+++ b/src/features/timer-stopwatch/lib/types.ts
@@ -1,0 +1,25 @@
+export type TimerStatus = "idle" | "running" | "paused" | "completed";
+
+export type Timer = {
+  id: string;
+  title: string;
+  durationMs: number;
+  remainingMs: number;
+  endsAt: number | null;
+  status: TimerStatus;
+};
+
+export type Lap = {
+  id: string;
+  totalMs: number;
+  splitMs: number;
+};
+
+export type StopwatchStatus = "idle" | "running" | "paused";
+
+export type Stopwatch = {
+  status: StopwatchStatus;
+  accumulatedMs: number;
+  startedAt: number | null;
+  laps: Lap[];
+};

--- a/src/features/timer-stopwatch/lib/use-now.ts
+++ b/src/features/timer-stopwatch/lib/use-now.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useMemo, useSyncExternalStore } from "react";
+
+function serverSnapshot(): number {
+  return 0;
+}
+
+export function useNow(intervalMs: number, active: boolean): number {
+  const subscribe = useMemo(() => {
+    return (onChange: () => void) => {
+      if (!active) return () => {};
+      const handle = setInterval(onChange, intervalMs);
+      return () => clearInterval(handle);
+    };
+  }, [active, intervalMs]);
+
+  return useSyncExternalStore(subscribe, Date.now, serverSnapshot);
+}

--- a/src/features/timer-stopwatch/lib/use-stopwatch.ts
+++ b/src/features/timer-stopwatch/lib/use-stopwatch.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import type { Stopwatch } from "./types";
 import {
   createStopwatch,
@@ -10,8 +10,6 @@ import {
   startStopwatch,
 } from "./stopwatch-engine";
 
-const TICK_INTERVAL_MS = 100;
-
 let nextLapId = 1;
 
 function generateLapId(): string {
@@ -20,15 +18,6 @@ function generateLapId(): string {
 
 export function useStopwatch() {
   const [stopwatch, setStopwatch] = useState<Stopwatch>(createStopwatch);
-  const [, setNow] = useState(0);
-
-  useEffect(() => {
-    if (stopwatch.status !== "running") return;
-    const handle = setInterval(() => {
-      setNow(Date.now());
-    }, TICK_INTERVAL_MS);
-    return () => clearInterval(handle);
-  }, [stopwatch.status]);
 
   const start = useCallback(() => {
     setStopwatch((prev) => startStopwatch(prev, Date.now()));

--- a/src/features/timer-stopwatch/lib/use-stopwatch.ts
+++ b/src/features/timer-stopwatch/lib/use-stopwatch.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { Stopwatch } from "./types";
+import {
+  createStopwatch,
+  pauseStopwatch,
+  recordLap,
+  resetStopwatch,
+  startStopwatch,
+} from "./stopwatch-engine";
+
+const TICK_INTERVAL_MS = 100;
+
+let nextLapId = 1;
+
+function generateLapId(): string {
+  return `lap-${nextLapId++}`;
+}
+
+export function useStopwatch() {
+  const [stopwatch, setStopwatch] = useState<Stopwatch>(createStopwatch);
+  const [, setNow] = useState(0);
+
+  useEffect(() => {
+    if (stopwatch.status !== "running") return;
+    const handle = setInterval(() => {
+      setNow(Date.now());
+    }, TICK_INTERVAL_MS);
+    return () => clearInterval(handle);
+  }, [stopwatch.status]);
+
+  const start = useCallback(() => {
+    setStopwatch((prev) => startStopwatch(prev, Date.now()));
+  }, []);
+
+  const pause = useCallback(() => {
+    setStopwatch((prev) => pauseStopwatch(prev, Date.now()));
+  }, []);
+
+  const reset = useCallback(() => {
+    setStopwatch(resetStopwatch());
+  }, []);
+
+  const lap = useCallback(() => {
+    setStopwatch((prev) => recordLap(prev, Date.now(), generateLapId()));
+  }, []);
+
+  return { stopwatch, start, pause, reset, lap };
+}

--- a/src/features/timer-stopwatch/lib/use-timers.ts
+++ b/src/features/timer-stopwatch/lib/use-timers.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Timer } from "./types";
 import {
   createTimer,
@@ -21,6 +21,11 @@ function generateId(): string {
 
 export function useTimers() {
   const [timers, setTimers] = useState<Timer[]>([]);
+  const timersRef = useRef(timers);
+
+  useEffect(() => {
+    timersRef.current = timers;
+  }, [timers]);
 
   const hasRunning = timers.some((t) => t.status === "running");
 
@@ -29,19 +34,20 @@ export function useTimers() {
 
     const handle = setInterval(() => {
       const now = Date.now();
+      const current = timersRef.current;
       const completedTitles: string[] = [];
-      setTimers((prev) => {
-        let changed = false;
-        const next = prev.map((t) => {
-          const { timer, justCompleted } = tickTimer(t, now);
-          if (justCompleted) {
-            completedTitles.push(timer.title);
-          }
-          if (timer !== t) changed = true;
-          return timer;
-        });
-        return changed ? next : prev;
+      let changed = false;
+      const next = current.map((t) => {
+        const { timer, justCompleted } = tickTimer(t, now);
+        if (justCompleted) {
+          completedTitles.push(timer.title);
+        }
+        if (timer !== t) changed = true;
+        return timer;
       });
+      if (changed) {
+        setTimers(next);
+      }
       completedTitles.forEach((title) => notifyTimerDone(title));
     }, TICK_INTERVAL_MS);
 

--- a/src/features/timer-stopwatch/lib/use-timers.ts
+++ b/src/features/timer-stopwatch/lib/use-timers.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { Timer } from "./types";
+import {
+  createTimer,
+  pauseTimer,
+  resetTimer,
+  startTimer,
+  tickTimer,
+} from "./timer-engine";
+import { ensureNotificationPermission, notifyTimerDone } from "./notifications";
+
+const TICK_INTERVAL_MS = 100;
+
+let nextId = 1;
+
+function generateId(): string {
+  return `timer-${nextId++}`;
+}
+
+export function useTimers() {
+  const [timers, setTimers] = useState<Timer[]>([]);
+
+  const hasRunning = timers.some((t) => t.status === "running");
+
+  useEffect(() => {
+    if (!hasRunning) return;
+
+    const handle = setInterval(() => {
+      const now = Date.now();
+      const completedTitles: string[] = [];
+      setTimers((prev) => {
+        let changed = false;
+        const next = prev.map((t) => {
+          const { timer, justCompleted } = tickTimer(t, now);
+          if (justCompleted) {
+            completedTitles.push(timer.title);
+          }
+          if (timer !== t) changed = true;
+          return timer;
+        });
+        return changed ? next : prev;
+      });
+      completedTitles.forEach((title) => notifyTimerDone(title));
+    }, TICK_INTERVAL_MS);
+
+    return () => clearInterval(handle);
+  }, [hasRunning]);
+
+  const addTimer = useCallback((title: string, durationMs: number) => {
+    if (durationMs <= 0) return;
+    const trimmed = title.trim() || "タイマー";
+    setTimers((prev) => [...prev, createTimer(generateId(), trimmed, durationMs)]);
+    void ensureNotificationPermission();
+  }, []);
+
+  const start = useCallback((id: string) => {
+    const now = Date.now();
+    setTimers((prev) => prev.map((t) => (t.id === id ? startTimer(t, now) : t)));
+    void ensureNotificationPermission();
+  }, []);
+
+  const pause = useCallback((id: string) => {
+    const now = Date.now();
+    setTimers((prev) => prev.map((t) => (t.id === id ? pauseTimer(t, now) : t)));
+  }, []);
+
+  const reset = useCallback((id: string) => {
+    setTimers((prev) => prev.map((t) => (t.id === id ? resetTimer(t) : t)));
+  }, []);
+
+  const remove = useCallback((id: string) => {
+    setTimers((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return { timers, addTimer, start, pause, reset, remove };
+}


### PR DESCRIPTION
## Summary
- カウントダウンタイマー（5分 / 10分 / 25分ポモドーロのプリセット、複数同時実行、タイトル付き）とストップウォッチ（ラップタイム記録）を実装
- タイマー完了時にブラウザ通知 + Web Audio API 生成のビープ音で通知（通知許可は遅延要求、拒否時はサウンドのみ）
- ピュア関数のエンジン層（`timer-engine` / `stopwatch-engine` / `format-time`）を Jest でカバー（新規テスト32件）
- React 19 の `react-hooks/purity` / `set-state-in-effect` ルールに適合させるため、時刻の鮮度を担保する `useSyncExternalStore` ベースの `useNow` フックを導入（開始直後の表示ずれも解消）

Closes #33

## Test plan
- [ ] `npm run lint` がエラーなく通る
- [ ] `npm run test` がグリーン
- [ ] `npm run build` が成功する
- [ ] ホーム `/` に「Timer / Stopwatch」カードが表示される
- [ ] `/tools/timer-stopwatch` で Tabs により Timer / Stopwatch を切替できる
- [ ] プリセット 5 分でタイマーを追加し、開始直後に "05:00" が正しく表示される（05:04 のような一瞬のずれがない）
- [ ] 一時停止 → 再開でカウントダウンが継続する
- [ ] 短時間（例: 10 秒）のタイマー完了時にブラウザ通知とビープ音が鳴る
- [ ] 複数タイマーを同時実行して独立に動作する
- [ ] ストップウォッチで開始 → ラップを複数回押し、split / total が正しい
- [ ] リセットでストップウォッチが 00:00.00 に戻る
- [ ] ダークモード時に UI が崩れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)