### PR TITLE
enhance: トップページのツール一覧をカテゴリ別にグループ化

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -33,7 +33,7 @@ Strictly separate routing, UI, and logic into three layers:
 
 1. Create `src/features/<tool-name>/components/` and `src/features/<tool-name>/lib/`
 2. Create `src/app/tools/<tool-name>/page.tsx` and import from the feature
-3. Add a tool entry to the `tools` array in `src/app/page.tsx` with a `category` value selected from the `ToolCategory` union type. **Do not force-fit a tool into an existing category when none is genuinely appropriate.** If no existing category fits, propose adding a new category to the user and wait for confirmation before proceeding. Adding a new category requires updating both the `ToolCategory` union and the `CATEGORIES` array in `src/app/page.tsx`.
+3. Add a tool entry to the `tools` array in `src/app/page.tsx` with a `category` value selected from the `ToolCategory` union type. **Do not force-fit a tool into an existing category when none is genuinely appropriate.** If no existing category fits, propose adding a new category to the user and wait for confirmation before proceeding. Adding a new category requires only adding an entry to the `CATEGORIES` array in `src/app/page.tsx` — `ToolCategory` is derived from `CATEGORIES`, so it updates automatically.
 
 ### Scaffold Template
 

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -33,7 +33,7 @@ Strictly separate routing, UI, and logic into three layers:
 
 1. Create `src/features/<tool-name>/components/` and `src/features/<tool-name>/lib/`
 2. Create `src/app/tools/<tool-name>/page.tsx` and import from the feature
-3. Add a tool entry to the `tools` array in `src/app/page.tsx` with a `category` value selected from the `ToolCategory` union type. If no existing category fits, ask the user before adding a new one — adding a new category requires updating both the `ToolCategory` union and the `CATEGORIES` array in `src/app/page.tsx`.
+3. Add a tool entry to the `tools` array in `src/app/page.tsx` with a `category` value selected from the `ToolCategory` union type. **Do not force-fit a tool into an existing category when none is genuinely appropriate.** If no existing category fits, propose adding a new category to the user and wait for confirmation before proceeding. Adding a new category requires updating both the `ToolCategory` union and the `CATEGORIES` array in `src/app/page.tsx`.
 
 ### Scaffold Template
 

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -33,7 +33,7 @@ Strictly separate routing, UI, and logic into three layers:
 
 1. Create `src/features/<tool-name>/components/` and `src/features/<tool-name>/lib/`
 2. Create `src/app/tools/<tool-name>/page.tsx` and import from the feature
-3. Add a tool entry to the `tools` array in `src/app/page.tsx`
+3. Add a tool entry to the `tools` array in `src/app/page.tsx` with a `category` value selected from the `ToolCategory` union type. If no existing category fits, ask the user before adding a new one — adding a new category requires updating both the `ToolCategory` union and the `CATEGORIES` array in `src/app/page.tsx`.
 
 ### Scaffold Template
 
@@ -76,6 +76,7 @@ export function <ToolName>Page() {
   description: "TODO: Tool description",
   href: "/tools/<tool>",
   icon: Package,
+  category: "<category-id>", // one of the ToolCategory union values
 },
 ```
-Note: The `Package` icon requires an import from `lucide-react`. Add the import if not already present.
+Note: The `Package` icon requires an import from `lucide-react`. Add the import if not already present. The `category` field is required — TypeScript will error if it is missing or uses a value outside the `ToolCategory` union.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,11 +7,22 @@ import {
   CardDescription,
 } from "@/components/ui/card";
 
+type ToolCategory = "text" | "encode-convert" | "generator" | "dev-support" | "calc-time";
+
+const CATEGORIES: { id: ToolCategory; label: string }[] = [
+  { id: "text", label: "テキスト" },
+  { id: "encode-convert", label: "エンコード / 変換" },
+  { id: "generator", label: "ジェネレーター" },
+  { id: "dev-support", label: "開発支援" },
+  { id: "calc-time", label: "計算 / 時間" },
+];
+
 type Tool = {
   name: string;
   description: string;
   href: string;
   icon: LucideIcon;
+  category: ToolCategory;
 };
 
 const tools: Tool[] = [
@@ -20,84 +31,98 @@ const tools: Tool[] = [
     description: "UUID v4/v7・ULID生成、一括生成＆コピー",
     href: "/tools/uuid-generator",
     icon: Fingerprint,
+    category: "generator",
   },
   {
     name: "Text Rewriter",
     description: "テキストのトーン変換・翻訳・要約・校正",
     href: "/tools/text-rewriter",
     icon: Languages,
+    category: "text",
   },
   {
     name: "JSON Formatter",
     description: "JSONの整形・検証",
     href: "/tools/json-formatter",
     icon: Braces,
+    category: "encode-convert",
   },
   {
     name: "Markdown Preview",
     description: "Markdownのリアルタイムプレビュー・HTMLコピー",
     href: "/tools/markdown-preview",
     icon: FileText,
+    category: "text",
   },
   {
     name: "Base64 Encoder / Decoder",
     description: "テキスト⇔Base64の相互変換、ファイルエンコード・Data URI生成",
     href: "/tools/base64-encoder-decoder",
     icon: Package,
+    category: "encode-convert",
   },
   {
     name: "Cron Expression Editor",
     description: "Cron式の組み立て・検証、次回実行予定の表示",
     href: "/tools/cron-expression-editor",
     icon: Clock,
+    category: "dev-support",
   },
   {
     name: "Color Converter",
     description: "HEX / RGB / HSL / Tailwind色名の相互変換、コントラスト比チェック",
     href: "/tools/color-converter",
     icon: Palette,
+    category: "encode-convert",
   },
   {
     name: "Diff Viewer",
     description: "テキスト・JSONの差分表示、行単位/単語単位のdiffモード、unified diffエクスポート",
     href: "/tools/diff-viewer",
     icon: FileDiff,
+    category: "text",
   },
   {
     name: "Character Counter",
     description: "文字数・単語数・行数・バイト数のリアルタイムカウント、プラットフォーム別残り文字数表示",
     href: "/tools/character-counter",
     icon: Type,
+    category: "text",
   },
   {
     name: "Regex Tester",
     description: "正規表現のパターンマッチをリアルタイムで検証、キャプチャグループ表示、置換プレビュー",
     href: "/tools/regex-tester",
     icon: Regex,
+    category: "dev-support",
   },
   {
     name: "QR Code Generator",
     description: "URLやテキストからQRコード生成、サイズ・色・ロゴのカスタマイズ、PNG/SVGダウンロード",
     href: "/tools/qr-code-generator",
     icon: QrCode,
+    category: "generator",
   },
   {
     name: "Unit Converter",
     description: "長さ・重さ・温度など各種単位を変換、計算式の表示",
     href: "/tools/unit-converter",
     icon: ArrowLeftRight,
+    category: "encode-convert",
   },
   {
     name: "Split Bill Calculator",
     description: "割り勘計算、端数処理、傾斜配分、税・サービス料の別計算",
     href: "/tools/split-bill-calculator",
     icon: Calculator,
+    category: "calc-time",
   },
   {
     name: "Timer / Stopwatch",
     description: "カウントダウンタイマー・ストップウォッチ、プリセット・複数同時実行・ブラウザ通知",
     href: "/tools/timer-stopwatch",
     icon: Timer,
+    category: "calc-time",
   },
 ];
 
@@ -117,26 +142,37 @@ export default function Home() {
           </p>
         </div>
       ) : (
-        <div className="mt-8 grid gap-4 sm:grid-cols-2">
-          {tools.map((tool) => {
-            const Icon = tool.icon;
+        <div className="mt-8 space-y-10">
+          {CATEGORIES.map(({ id, label }) => {
+            const categoryTools = tools.filter((tool) => tool.category === id);
+            if (categoryTools.length === 0) return null;
             return (
-              <Link key={tool.href} href={tool.href} className="h-full">
-                <Card className="group h-full transition-colors hover:bg-muted/50">
-                  <CardHeader className="flex flex-row items-center gap-4">
-                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                      <Icon className="h-5 w-5" aria-hidden="true" />
-                    </div>
-                    <div className="flex-1 space-y-1">
-                      <CardTitle className="flex items-center justify-between">
-                        {tool.name}
-                        <ArrowRight className="h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100 text-muted-foreground" aria-hidden="true" />
-                      </CardTitle>
-                      <CardDescription>{tool.description}</CardDescription>
-                    </div>
-                  </CardHeader>
-                </Card>
-              </Link>
+              <section key={id}>
+                <h2 className="text-xl font-semibold tracking-tight">{label}</h2>
+                <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                  {categoryTools.map((tool) => {
+                    const Icon = tool.icon;
+                    return (
+                      <Link key={tool.href} href={tool.href} className="h-full">
+                        <Card className="group h-full transition-colors hover:bg-muted/50">
+                          <CardHeader className="flex flex-row items-center gap-4">
+                            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                              <Icon className="h-5 w-5" aria-hidden="true" />
+                            </div>
+                            <div className="flex-1 space-y-1">
+                              <CardTitle className="flex items-center justify-between">
+                                {tool.name}
+                                <ArrowRight className="h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100 text-muted-foreground" aria-hidden="true" />
+                              </CardTitle>
+                              <CardDescription>{tool.description}</CardDescription>
+                            </div>
+                          </CardHeader>
+                        </Card>
+                      </Link>
+                    );
+                  })}
+                </div>
+              </section>
             );
           })}
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,15 +7,15 @@ import {
   CardDescription,
 } from "@/components/ui/card";
 
-type ToolCategory = "text" | "encode-convert" | "generator" | "dev-support" | "calc-time";
-
-const CATEGORIES: { id: ToolCategory; label: string }[] = [
+const CATEGORIES = [
   { id: "text", label: "テキスト" },
   { id: "encode-convert", label: "エンコード / 変換" },
   { id: "generator", label: "ジェネレーター" },
   { id: "dev-support", label: "開発支援" },
   { id: "calc-time", label: "計算 / 時間" },
-];
+] as const;
+
+type ToolCategory = (typeof CATEGORIES)[number]["id"];
 
 type Tool = {
   name: string;


### PR DESCRIPTION
## Summary
- `ToolCategory` ユニオン型と `CATEGORIES` 配列を追加し、`Tool` 型に必須の `category` フィールドを導入。カテゴリ未指定はコンパイルエラーで検知できる
- 既存14ツールに「テキスト / エンコード変換 / ジェネレーター / 開発支援 / 計算時間」のカテゴリを割当て、トップページをカテゴリ別セクションでグループ化（Server Component のまま）
- `.claude/rules/architecture.md` の「Adding a New Tool」手順とスカフォールドテンプレートに `category` 必須を反映

Closes #175

## Test plan
- [ ] `npm run lint` がパスすること
- [ ] `npm run build` がパスすること（`category` 必須化の型チェック含む）
- [ ] `npm run test` がパスすること
- [ ] `npm run dev` でトップページを開き、5つのカテゴリ見出しと14ツールが定義順に表示されることを確認
- [ ] カードのリンク・ホバー挙動が従来通り動作することを確認
- [ ] ライト/ダーク両テーマで見出しが視認できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)