### PR TITLE
feat: 天気ダッシュボードツールを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
+        "recharts": "^3.8.0",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0"
@@ -4518,6 +4519,42 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -4571,6 +4608,18 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -5123,6 +5172,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -5341,6 +5453,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
@@ -7207,6 +7325,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -7323,6 +7562,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -7864,6 +8109,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
+      "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -8357,6 +8612,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -9481,6 +9742,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -9576,6 +9847,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -14653,7 +14933,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-markdown": {
@@ -14681,6 +14960,29 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-remove-scroll": {
@@ -14769,6 +15071,36 @@
         "node": ">= 4"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -14781,6 +15113,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -14934,6 +15281,12 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -16232,7 +16585,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
@@ -16990,6 +17342,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.8.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0"

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -1,0 +1,210 @@
+import { NextResponse } from "next/server";
+import { createRateLimit } from "@/lib/rate-limit";
+import { getClientIp, rateLimitResponse } from "@/lib/api-helpers";
+import type {
+  GeocodingResponse,
+  GeocodingResult,
+  WeatherForecast,
+} from "@/features/weather-dashboard/lib/types";
+
+const FORECAST_URL = "https://api.open-meteo.com/v1/forecast";
+const GEOCODE_URL = "https://geocoding-api.open-meteo.com/v1/search";
+
+const MAX_QUERY_LENGTH = 100;
+
+const rateLimit = createRateLimit({ limit: 30, windowMs: 60_000 });
+
+export async function GET(request: Request) {
+  const ip = getClientIp(request);
+  if (ip !== "unknown") {
+    const result = rateLimit.check(ip);
+    if (!result.allowed) {
+      return rateLimitResponse(result.retryAfterMs);
+    }
+  }
+
+  const { searchParams } = new URL(request.url);
+  const mode = searchParams.get("mode");
+
+  if (mode === "forecast") {
+    return handleForecast(searchParams);
+  }
+  if (mode === "geocode") {
+    return handleGeocode(searchParams);
+  }
+  return NextResponse.json(
+    { error: "mode は forecast または geocode を指定してください。", errorCode: "VALIDATION_ERROR" },
+    { status: 400 }
+  );
+}
+
+async function handleForecast(params: URLSearchParams): Promise<Response> {
+  const latStr = params.get("lat");
+  const lonStr = params.get("lon");
+  const lat = latStr ? Number(latStr) : NaN;
+  const lon = lonStr ? Number(lonStr) : NaN;
+
+  if (
+    !Number.isFinite(lat) ||
+    !Number.isFinite(lon) ||
+    lat < -90 ||
+    lat > 90 ||
+    lon < -180 ||
+    lon > 180
+  ) {
+    return NextResponse.json(
+      { error: "緯度・経度の指定が不正です。", errorCode: "VALIDATION_ERROR" },
+      { status: 400 }
+    );
+  }
+
+  const url = new URL(FORECAST_URL);
+  url.searchParams.set("latitude", String(lat));
+  url.searchParams.set("longitude", String(lon));
+  url.searchParams.set(
+    "current",
+    "temperature_2m,relative_humidity_2m,precipitation_probability,wind_speed_10m,weather_code"
+  );
+  url.searchParams.set("hourly", "temperature_2m,precipitation_probability");
+  url.searchParams.set(
+    "daily",
+    "weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max"
+  );
+  url.searchParams.set("timezone", "auto");
+  url.searchParams.set("forecast_days", "7");
+  url.searchParams.set("forecast_hours", "24");
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(url, { headers: { Accept: "application/json" } });
+  } catch {
+    return NextResponse.json(
+      { error: "天気サービスに接続できませんでした。", errorCode: "UPSTREAM_ERROR" },
+      { status: 502 }
+    );
+  }
+
+  if (!upstream.ok) {
+    return NextResponse.json(
+      { error: "天気データの取得に失敗しました。", errorCode: "UPSTREAM_ERROR" },
+      { status: 502 }
+    );
+  }
+
+  const raw = (await upstream.json()) as OpenMeteoForecastResponse;
+  const forecast = mapForecast(raw);
+  return NextResponse.json(forecast);
+}
+
+async function handleGeocode(params: URLSearchParams): Promise<Response> {
+  const query = params.get("q")?.trim() ?? "";
+  if (query.length === 0 || query.length > MAX_QUERY_LENGTH) {
+    return NextResponse.json(
+      { error: "検索キーワードは1〜100文字で指定してください。", errorCode: "VALIDATION_ERROR" },
+      { status: 400 }
+    );
+  }
+
+  const url = new URL(GEOCODE_URL);
+  url.searchParams.set("name", query);
+  url.searchParams.set("count", "5");
+  url.searchParams.set("language", "ja");
+  url.searchParams.set("format", "json");
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(url, { headers: { Accept: "application/json" } });
+  } catch {
+    return NextResponse.json(
+      { error: "都市検索サービスに接続できませんでした。", errorCode: "UPSTREAM_ERROR" },
+      { status: 502 }
+    );
+  }
+
+  if (!upstream.ok) {
+    return NextResponse.json(
+      { error: "都市検索に失敗しました。", errorCode: "UPSTREAM_ERROR" },
+      { status: 502 }
+    );
+  }
+
+  const raw = (await upstream.json()) as OpenMeteoGeocodingResponse;
+  const response: GeocodingResponse = {
+    results: (raw.results ?? []).map(mapGeocodingResult),
+  };
+  return NextResponse.json(response);
+}
+
+type OpenMeteoForecastResponse = {
+  timezone: string;
+  current: {
+    time: string;
+    temperature_2m: number;
+    relative_humidity_2m: number;
+    precipitation_probability: number;
+    wind_speed_10m: number;
+    weather_code: number;
+  };
+  hourly: {
+    time: string[];
+    temperature_2m: number[];
+    precipitation_probability: number[];
+  };
+  daily: {
+    time: string[];
+    weather_code: number[];
+    temperature_2m_max: number[];
+    temperature_2m_min: number[];
+    precipitation_probability_max: number[];
+  };
+};
+
+type OpenMeteoGeocodingResponse = {
+  results?: Array<{
+    id: number;
+    name: string;
+    latitude: number;
+    longitude: number;
+    country?: string;
+    admin1?: string;
+  }>;
+};
+
+function mapForecast(raw: OpenMeteoForecastResponse): WeatherForecast {
+  const hourly: WeatherForecast["hourly"] = raw.hourly.time.map((time, idx) => ({
+    time,
+    temperature: raw.hourly.temperature_2m[idx],
+    precipitationProbability: raw.hourly.precipitation_probability[idx] ?? 0,
+  }));
+  const daily: WeatherForecast["daily"] = raw.daily.time.map((date, idx) => ({
+    date,
+    weatherCode: raw.daily.weather_code[idx],
+    temperatureMax: raw.daily.temperature_2m_max[idx],
+    temperatureMin: raw.daily.temperature_2m_min[idx],
+    precipitationProbabilityMax: raw.daily.precipitation_probability_max[idx] ?? 0,
+  }));
+  return {
+    timezone: raw.timezone,
+    current: {
+      time: raw.current.time,
+      temperature: raw.current.temperature_2m,
+      humidity: raw.current.relative_humidity_2m,
+      precipitationProbability: raw.current.precipitation_probability ?? 0,
+      windSpeed: raw.current.wind_speed_10m,
+      weatherCode: raw.current.weather_code,
+    },
+    hourly,
+    daily,
+  };
+}
+
+function mapGeocodingResult(raw: NonNullable<OpenMeteoGeocodingResponse["results"]>[number]): GeocodingResult {
+  return {
+    id: raw.id,
+    name: raw.name,
+    latitude: raw.latitude,
+    longitude: raw.longitude,
+    country: raw.country,
+    admin1: raw.admin1,
+  };
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, ArrowLeftRight, Braces, Calculator, Clock, FileText, Fingerprint, FileDiff, Languages, Palette, Package, QrCode, Regex, Timer, Type, type LucideIcon } from "lucide-react";
+import { ArrowRight, ArrowLeftRight, Braces, Calculator, Clock, Cloud, FileText, Fingerprint, FileDiff, Languages, Palette, Package, QrCode, Regex, Timer, Type, type LucideIcon } from "lucide-react";
 import {
   Card,
   CardHeader,
@@ -13,6 +13,7 @@ const CATEGORIES = [
   { id: "generator", label: "ジェネレーター" },
   { id: "dev-support", label: "開発支援" },
   { id: "calc-time", label: "計算 / 時間" },
+  { id: "external-api", label: "外部API活用" },
 ] as const;
 
 type ToolCategory = (typeof CATEGORIES)[number]["id"];
@@ -123,6 +124,13 @@ const tools: Tool[] = [
     href: "/tools/timer-stopwatch",
     icon: Timer,
     category: "calc-time",
+  },
+  {
+    name: "Weather Dashboard",
+    description: "現在地または都市名検索で現在の天気・時間別気温・週間予報を表示",
+    href: "/tools/weather-dashboard",
+    icon: Cloud,
+    category: "external-api",
   },
 ];
 

--- a/src/app/tools/weather-dashboard/page.tsx
+++ b/src/app/tools/weather-dashboard/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import { WeatherDashboardPage } from "@/features/weather-dashboard/components/weather-dashboard-page";
+
+export const metadata: Metadata = {
+  title: "Weather Dashboard - Personal Tools",
+  description: "現在の天気と週間予報を表示するダッシュボード",
+};
+
+export default function Page() {
+  return <WeatherDashboardPage />;
+}

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,0 +1,374 @@
+"use client"
+
+import * as React from "react"
+import * as RechartsPrimitive from "recharts"
+import type { TooltipValueType } from "recharts"
+
+import { cn } from "@/lib/utils"
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const
+
+const INITIAL_DIMENSION = { width: 320, height: 200 } as const
+type TooltipNameType = number | string
+
+export type ChartConfig = Record<
+  string,
+  {
+    label?: React.ReactNode
+    icon?: React.ComponentType
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  )
+>
+
+type ChartContextProps = {
+  config: ChartConfig
+}
+
+const ChartContext = React.createContext<ChartContextProps | null>(null)
+
+function useChart() {
+  const context = React.useContext(ChartContext)
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />")
+  }
+
+  return context
+}
+
+function ChartContainer({
+  id,
+  className,
+  children,
+  config,
+  initialDimension = INITIAL_DIMENSION,
+  ...props
+}: React.ComponentProps<"div"> & {
+  config: ChartConfig
+  children: React.ComponentProps<
+    typeof RechartsPrimitive.ResponsiveContainer
+  >["children"]
+  initialDimension?: {
+    width: number
+    height: number
+  }
+}) {
+  const uniqueId = React.useId()
+  const chartId = `chart-${id ?? uniqueId.replace(/:/g, "")}`
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-slot="chart"
+        data-chart={chartId}
+        className={cn(
+          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          className
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer
+          initialDimension={initialDimension}
+        >
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  )
+}
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(
+    ([, config]) => config.theme ?? config.color
+  )
+
+  if (!colorConfig.length) {
+    return null
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ??
+      itemConfig.color
+    return color ? `  --color-${key}: ${color};` : null
+  })
+  .join("\n")}
+}
+`
+          )
+          .join("\n"),
+      }}
+    />
+  )
+}
+
+const ChartTooltip = RechartsPrimitive.Tooltip
+
+function ChartTooltipContent({
+  active,
+  payload,
+  className,
+  indicator = "dot",
+  hideLabel = false,
+  hideIndicator = false,
+  label,
+  labelFormatter,
+  labelClassName,
+  formatter,
+  color,
+  nameKey,
+  labelKey,
+}: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+  React.ComponentProps<"div"> & {
+    hideLabel?: boolean
+    hideIndicator?: boolean
+    indicator?: "line" | "dot" | "dashed"
+    nameKey?: string
+    labelKey?: string
+  } & Omit<
+    RechartsPrimitive.DefaultTooltipContentProps<
+      TooltipValueType,
+      TooltipNameType
+    >,
+    "accessibilityLayer"
+  >) {
+  const { config } = useChart()
+
+  const tooltipLabel = React.useMemo(() => {
+    if (hideLabel || !payload?.length) {
+      return null
+    }
+
+    const [item] = payload
+    const key = `${labelKey ?? item?.dataKey ?? item?.name ?? "value"}`
+    const itemConfig = getPayloadConfigFromPayload(config, item, key)
+    const value =
+      !labelKey && typeof label === "string"
+        ? (config[label]?.label ?? label)
+        : itemConfig?.label
+
+    if (labelFormatter) {
+      return (
+        <div className={cn("font-medium", labelClassName)}>
+          {labelFormatter(value, payload)}
+        </div>
+      )
+    }
+
+    if (!value) {
+      return null
+    }
+
+    return <div className={cn("font-medium", labelClassName)}>{value}</div>
+  }, [
+    label,
+    labelFormatter,
+    payload,
+    hideLabel,
+    labelClassName,
+    config,
+    labelKey,
+  ])
+
+  if (!active || !payload?.length) {
+    return null
+  }
+
+  const nestLabel = payload.length === 1 && indicator !== "dot"
+
+  return (
+    <div
+      className={cn(
+        "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+        className
+      )}
+    >
+      {!nestLabel ? tooltipLabel : null}
+      <div className="grid gap-1.5">
+        {payload
+          .filter((item) => item.type !== "none")
+          .map((item, index) => {
+            const key = `${nameKey ?? item.name ?? item.dataKey ?? "value"}`
+            const itemConfig = getPayloadConfigFromPayload(config, item, key)
+            const indicatorColor = color ?? item.payload?.fill ?? item.color
+
+            return (
+              <div
+                key={index}
+                className={cn(
+                  "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+                  indicator === "dot" && "items-center"
+                )}
+              >
+                {formatter && item?.value !== undefined && item.name ? (
+                  formatter(item.value, item.name, item, index, item.payload)
+                ) : (
+                  <>
+                    {itemConfig?.icon ? (
+                      <itemConfig.icon />
+                    ) : (
+                      !hideIndicator && (
+                        <div
+                          className={cn(
+                            "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+                            {
+                              "h-2.5 w-2.5": indicator === "dot",
+                              "w-1": indicator === "line",
+                              "w-0 border-[1.5px] border-dashed bg-transparent":
+                                indicator === "dashed",
+                              "my-0.5": nestLabel && indicator === "dashed",
+                            }
+                          )}
+                          style={
+                            {
+                              "--color-bg": indicatorColor,
+                              "--color-border": indicatorColor,
+                            } as React.CSSProperties
+                          }
+                        />
+                      )
+                    )}
+                    <div
+                      className={cn(
+                        "flex flex-1 justify-between leading-none",
+                        nestLabel ? "items-end" : "items-center"
+                      )}
+                    >
+                      <div className="grid gap-1.5">
+                        {nestLabel ? tooltipLabel : null}
+                        <span className="text-muted-foreground">
+                          {itemConfig?.label ?? item.name}
+                        </span>
+                      </div>
+                      {item.value != null && (
+                        <span className="font-mono font-medium text-foreground tabular-nums">
+                          {typeof item.value === "number"
+                            ? item.value.toLocaleString()
+                            : String(item.value)}
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            )
+          })}
+      </div>
+    </div>
+  )
+}
+
+const ChartLegend = RechartsPrimitive.Legend
+
+function ChartLegendContent({
+  className,
+  hideIcon = false,
+  payload,
+  verticalAlign = "bottom",
+  nameKey,
+}: React.ComponentProps<"div"> & {
+  hideIcon?: boolean
+  nameKey?: string
+} & RechartsPrimitive.DefaultLegendContentProps) {
+  const { config } = useChart()
+
+  if (!payload?.length) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center gap-4",
+        verticalAlign === "top" ? "pb-3" : "pt-3",
+        className
+      )}
+    >
+      {payload
+        .filter((item) => item.type !== "none")
+        .map((item, index) => {
+          const key = `${nameKey ?? item.dataKey ?? "value"}`
+          const itemConfig = getPayloadConfigFromPayload(config, item, key)
+
+          return (
+            <div
+              key={index}
+              className={cn(
+                "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground"
+              )}
+            >
+              {itemConfig?.icon && !hideIcon ? (
+                <itemConfig.icon />
+              ) : (
+                <div
+                  className="h-2 w-2 shrink-0 rounded-[2px]"
+                  style={{
+                    backgroundColor: item.color,
+                  }}
+                />
+              )}
+              {itemConfig?.label}
+            </div>
+          )
+        })}
+    </div>
+  )
+}
+
+// Helper to extract item config from a payload.
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string
+) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined
+  }
+
+  const payloadPayload =
+    "payload" in payload &&
+    typeof payload.payload === "object" &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined
+
+  let configLabelKey: string = key
+
+  if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[
+      key as keyof typeof payloadPayload
+    ] as string
+  }
+
+  return configLabelKey in config ? config[configLabelKey] : config[key]
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+}

--- a/src/features/weather-dashboard/components/current-weather-card.tsx
+++ b/src/features/weather-dashboard/components/current-weather-card.tsx
@@ -1,0 +1,73 @@
+import { Droplets, Thermometer, Umbrella, Wind } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { CurrentWeather } from "../lib/types";
+import { describeWeatherCode } from "../lib/weather-summary";
+import { WeatherIcon } from "./weather-icon";
+
+type Props = {
+  current: CurrentWeather;
+  locationLabel: string;
+};
+
+export function CurrentWeatherCard({ current, locationLabel }: Props) {
+  const stats: Array<{
+    label: string;
+    value: string;
+    icon: typeof Thermometer;
+  }> = [
+    {
+      label: "気温",
+      value: `${current.temperature.toFixed(1)} ℃`,
+      icon: Thermometer,
+    },
+    {
+      label: "降水確率",
+      value: `${current.precipitationProbability}%`,
+      icon: Umbrella,
+    },
+    {
+      label: "湿度",
+      value: `${current.humidity}%`,
+      icon: Droplets,
+    },
+    {
+      label: "風速",
+      value: `${current.windSpeed.toFixed(1)} m/s`,
+      icon: Wind,
+    },
+  ];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-4">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <WeatherIcon code={current.weatherCode} className="h-7 w-7" />
+          </div>
+          <div className="flex flex-col gap-0.5">
+            <span className="text-sm font-normal text-muted-foreground">
+              {locationLabel}の現在の天気
+            </span>
+            <span className="text-xl">{describeWeatherCode(current.weatherCode)}</span>
+          </div>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          {stats.map(({ label, value, icon: Icon }) => (
+            <div
+              key={label}
+              className="flex flex-col items-start gap-2 rounded-lg border bg-card p-3"
+            >
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <Icon className="h-4 w-4" aria-hidden="true" />
+                <span className="text-sm">{label}</span>
+              </div>
+              <span className="text-2xl font-semibold tabular-nums">{value}</span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/weather-dashboard/components/daily-forecast-list.tsx
+++ b/src/features/weather-dashboard/components/daily-forecast-list.tsx
@@ -1,0 +1,69 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { DailyForecast } from "../lib/types";
+import { describeWeatherCode } from "../lib/weather-summary";
+import { WeatherIcon } from "./weather-icon";
+
+type Props = {
+  daily: DailyForecast[];
+};
+
+const WEEKDAY_FORMATTER = new Intl.DateTimeFormat("ja-JP", {
+  month: "numeric",
+  day: "numeric",
+  weekday: "short",
+});
+
+function formatDate(isoDate: string): string {
+  const d = new Date(`${isoDate}T00:00:00`);
+  return Number.isNaN(d.getTime()) ? isoDate : WEEKDAY_FORMATTER.format(d);
+}
+
+const ROW_GRID =
+  "grid grid-cols-[6rem_auto_1fr_4rem_6rem] items-center gap-3";
+
+export function DailyForecastList({ daily }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>週間予報</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div
+          className={`${ROW_GRID} border-b pb-2 text-xs font-medium text-muted-foreground`}
+        >
+          <span>日付</span>
+          <span className="col-span-2">天気</span>
+          <span className="text-right">降水</span>
+          <span className="text-right">気温</span>
+        </div>
+        <ul className="divide-y">
+          {daily.map((day) => (
+            <li key={day.date} className={`${ROW_GRID} py-2 text-sm`}>
+              <span className="font-medium">{formatDate(day.date)}</span>
+              <WeatherIcon
+                code={day.weatherCode}
+                className="h-5 w-5 text-muted-foreground"
+                label={describeWeatherCode(day.weatherCode)}
+              />
+              <span className="text-muted-foreground">
+                {describeWeatherCode(day.weatherCode)}
+              </span>
+              <span className="tabular-nums text-right text-muted-foreground">
+                {day.precipitationProbabilityMax}%
+              </span>
+              <span className="tabular-nums text-right">
+                <span className="inline-block w-8 text-right text-blue-600 dark:text-blue-400">
+                  {day.temperatureMin.toFixed(0)}°
+                </span>
+                <span className="mx-1 text-muted-foreground">/</span>
+                <span className="inline-block w-8 text-left text-red-600 dark:text-red-400">
+                  {day.temperatureMax.toFixed(0)}°
+                </span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/weather-dashboard/components/daily-forecast-list.tsx
+++ b/src/features/weather-dashboard/components/daily-forecast-list.tsx
@@ -11,11 +11,15 @@ const WEEKDAY_FORMATTER = new Intl.DateTimeFormat("ja-JP", {
   month: "numeric",
   day: "numeric",
   weekday: "short",
+  timeZone: "UTC",
 });
 
 function formatDate(isoDate: string): string {
-  const d = new Date(`${isoDate}T00:00:00`);
-  return Number.isNaN(d.getTime()) ? isoDate : WEEKDAY_FORMATTER.format(d);
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
+  if (!match) return isoDate;
+  const [, y, m, d] = match;
+  const date = new Date(Date.UTC(Number(y), Number(m) - 1, Number(d)));
+  return Number.isNaN(date.getTime()) ? isoDate : WEEKDAY_FORMATTER.format(date);
 }
 
 const ROW_GRID =
@@ -43,7 +47,6 @@ export function DailyForecastList({ daily }: Props) {
               <WeatherIcon
                 code={day.weatherCode}
                 className="h-5 w-5 text-muted-foreground"
-                label={describeWeatherCode(day.weatherCode)}
               />
               <span className="text-muted-foreground">
                 {describeWeatherCode(day.weatherCode)}

--- a/src/features/weather-dashboard/components/forecast-charts.tsx
+++ b/src/features/weather-dashboard/components/forecast-charts.tsx
@@ -23,25 +23,24 @@ type Props = {
   daily: DailyForecast[];
 };
 
-const HOUR_FORMATTER = new Intl.DateTimeFormat("ja-JP", {
-  hour: "2-digit",
-  minute: "2-digit",
-});
-
 const WEEKDAY_FORMATTER = new Intl.DateTimeFormat("ja-JP", {
   month: "numeric",
   day: "numeric",
   weekday: "short",
+  timeZone: "UTC",
 });
 
 function formatHour(isoTime: string): string {
-  const d = new Date(isoTime);
-  return Number.isNaN(d.getTime()) ? isoTime : HOUR_FORMATTER.format(d);
+  const match = /T(\d{2}:\d{2})/.exec(isoTime);
+  return match ? match[1] : isoTime;
 }
 
 function formatDate(isoDate: string): string {
-  const d = new Date(`${isoDate}T00:00:00`);
-  return Number.isNaN(d.getTime()) ? isoDate : WEEKDAY_FORMATTER.format(d);
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
+  if (!match) return isoDate;
+  const [, y, m, d] = match;
+  const date = new Date(Date.UTC(Number(y), Number(m) - 1, Number(d)));
+  return Number.isNaN(date.getTime()) ? isoDate : WEEKDAY_FORMATTER.format(date);
 }
 
 const hourlyConfig = {

--- a/src/features/weather-dashboard/components/forecast-charts.tsx
+++ b/src/features/weather-dashboard/components/forecast-charts.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import {
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import type { DailyForecast, HourlyPoint } from "../lib/types";
+
+type Props = {
+  hourly: HourlyPoint[];
+  daily: DailyForecast[];
+};
+
+const HOUR_FORMATTER = new Intl.DateTimeFormat("ja-JP", {
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+const WEEKDAY_FORMATTER = new Intl.DateTimeFormat("ja-JP", {
+  month: "numeric",
+  day: "numeric",
+  weekday: "short",
+});
+
+function formatHour(isoTime: string): string {
+  const d = new Date(isoTime);
+  return Number.isNaN(d.getTime()) ? isoTime : HOUR_FORMATTER.format(d);
+}
+
+function formatDate(isoDate: string): string {
+  const d = new Date(`${isoDate}T00:00:00`);
+  return Number.isNaN(d.getTime()) ? isoDate : WEEKDAY_FORMATTER.format(d);
+}
+
+const hourlyConfig = {
+  temperature: {
+    label: "気温",
+    color: "var(--chart-1)",
+  },
+  precipitation: {
+    label: "降水確率",
+    color: "var(--chart-2)",
+  },
+} satisfies ChartConfig;
+
+const dailyConfig = {
+  temperatureMax: {
+    label: "最高気温",
+    color: "var(--chart-1)",
+  },
+  precipitation: {
+    label: "降水確率",
+    color: "var(--chart-2)",
+  },
+} satisfies ChartConfig;
+
+const CHART_CLASS = "h-[260px] w-full";
+
+export function ForecastCharts({ hourly, daily }: Props) {
+  const hourlyData = hourly.map((p) => ({
+    label: formatHour(p.time),
+    temperature: p.temperature,
+    precipitation: p.precipitationProbability,
+  }));
+  const dailyData = daily.map((d) => ({
+    label: formatDate(d.date),
+    temperatureMax: d.temperatureMax,
+    precipitation: d.precipitationProbabilityMax,
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>予報グラフ</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Tabs defaultValue="hourly">
+          <TabsList>
+            <TabsTrigger value="hourly">時間別（気温・降水確率）</TabsTrigger>
+            <TabsTrigger value="daily">週間（気温・降水確率）</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="hourly" className="mt-4">
+            <ChartContainer config={hourlyConfig} className={CHART_CLASS}>
+              <ComposedChart
+                data={hourlyData}
+                margin={{ top: 8, right: 12, left: 0, bottom: 0 }}
+              >
+                <CartesianGrid vertical={false} strokeDasharray="3 3" />
+                <XAxis dataKey="label" tickLine={false} axisLine={false} minTickGap={24} />
+                <YAxis
+                  yAxisId="temperature"
+                  tickLine={false}
+                  axisLine={false}
+                  width={48}
+                  unit="℃"
+                />
+                <YAxis
+                  yAxisId="precipitation"
+                  orientation="right"
+                  tickLine={false}
+                  axisLine={false}
+                  width={48}
+                  unit="%"
+                  domain={[0, 100]}
+                />
+                <ChartTooltip content={<ChartTooltipContent indicator="line" />} />
+                <Bar
+                  yAxisId="precipitation"
+                  dataKey="precipitation"
+                  fill="var(--color-precipitation)"
+                  radius={[4, 4, 0, 0]}
+                  fillOpacity={0.5}
+                />
+                <Line
+                  yAxisId="temperature"
+                  type="monotone"
+                  dataKey="temperature"
+                  stroke="var(--color-temperature)"
+                  strokeWidth={2}
+                  dot={false}
+                />
+              </ComposedChart>
+            </ChartContainer>
+          </TabsContent>
+
+          <TabsContent value="daily" className="mt-4">
+            <ChartContainer config={dailyConfig} className={CHART_CLASS}>
+              <ComposedChart
+                data={dailyData}
+                margin={{ top: 8, right: 12, left: 0, bottom: 0 }}
+              >
+                <CartesianGrid vertical={false} strokeDasharray="3 3" />
+                <XAxis dataKey="label" tickLine={false} axisLine={false} />
+                <YAxis
+                  yAxisId="temperature"
+                  tickLine={false}
+                  axisLine={false}
+                  width={48}
+                  unit="℃"
+                />
+                <YAxis
+                  yAxisId="precipitation"
+                  orientation="right"
+                  tickLine={false}
+                  axisLine={false}
+                  width={48}
+                  unit="%"
+                  domain={[0, 100]}
+                />
+                <ChartTooltip content={<ChartTooltipContent indicator="line" />} />
+                <Bar
+                  yAxisId="precipitation"
+                  dataKey="precipitation"
+                  fill="var(--color-precipitation)"
+                  radius={[4, 4, 0, 0]}
+                  fillOpacity={0.5}
+                />
+                <Line
+                  yAxisId="temperature"
+                  type="monotone"
+                  dataKey="temperatureMax"
+                  stroke="var(--color-temperatureMax)"
+                  strokeWidth={2}
+                  dot={{ r: 3 }}
+                />
+              </ComposedChart>
+            </ChartContainer>
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/weather-dashboard/components/location-picker.tsx
+++ b/src/features/weather-dashboard/components/location-picker.tsx
@@ -30,8 +30,10 @@ export function LocationPicker({
   useEffect(() => {
     const trimmed = query.trim();
     if (trimmed.length === 0) {
+      requestIdRef.current += 1;
       setResults([]);
       setErrorMessage(null);
+      setSearching(false);
       return;
     }
     const requestId = requestIdRef.current + 1;

--- a/src/features/weather-dashboard/components/location-picker.tsx
+++ b/src/features/weather-dashboard/components/location-picker.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Loader2, MapPin, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { searchCities, WeatherError } from "../lib/weather-client";
+import type { GeocodingResult } from "../lib/types";
+
+type Props = {
+  onSelect: (result: GeocodingResult) => void;
+  onUseCurrentLocation: () => void;
+  geolocationDisabled: boolean;
+};
+
+const DEBOUNCE_MS = 350;
+
+export function LocationPicker({
+  onSelect,
+  onUseCurrentLocation,
+  geolocationDisabled,
+}: Props) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<GeocodingResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (trimmed.length === 0) {
+      setResults([]);
+      setErrorMessage(null);
+      return;
+    }
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    const handle = setTimeout(async () => {
+      setSearching(true);
+      setErrorMessage(null);
+      try {
+        const response = await searchCities(trimmed);
+        if (requestIdRef.current === requestId) {
+          setResults(response.results);
+        }
+      } catch (e) {
+        if (requestIdRef.current === requestId) {
+          const message =
+            e instanceof WeatherError
+              ? e.message
+              : "都市の検索に失敗しました。";
+          setErrorMessage(message);
+          setResults([]);
+        }
+      } finally {
+        if (requestIdRef.current === requestId) {
+          setSearching(false);
+        }
+      }
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+        <div className="flex-1 space-y-1">
+          <Label htmlFor="city-search">都市名で検索</Label>
+          <div className="relative">
+            <Search
+              aria-hidden="true"
+              className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              id="city-search"
+              type="search"
+              autoComplete="off"
+              placeholder="例: 東京 / Tokyo"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="pl-8"
+            />
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={onUseCurrentLocation}
+          disabled={geolocationDisabled}
+        >
+          <MapPin className="h-4 w-4" aria-hidden="true" />
+          現在地を使う
+        </Button>
+      </div>
+
+      {searching && (
+        <p className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          検索中...
+        </p>
+      )}
+
+      {errorMessage && (
+        <p className="text-sm text-destructive" role="alert">
+          {errorMessage}
+        </p>
+      )}
+
+      {!searching && results.length > 0 && (
+        <ul className="divide-y rounded-md border">
+          {results.map((result) => (
+            <li key={result.id}>
+              <button
+                type="button"
+                onClick={() => {
+                  onSelect(result);
+                  setQuery("");
+                  setResults([]);
+                }}
+                className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-muted/50"
+              >
+                <span className="font-medium">{result.name}</span>
+                <span className="text-xs text-muted-foreground">
+                  {[result.admin1, result.country].filter(Boolean).join(", ")}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {!searching && query.trim().length > 0 && results.length === 0 && !errorMessage && (
+        <p className="text-sm text-muted-foreground">該当する都市が見つかりませんでした。</p>
+      )}
+    </div>
+  );
+}

--- a/src/features/weather-dashboard/components/umbrella-summary.tsx
+++ b/src/features/weather-dashboard/components/umbrella-summary.tsx
@@ -1,0 +1,19 @@
+import { Umbrella } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { getUmbrellaSummary } from "../lib/weather-summary";
+import type { DailyForecast } from "../lib/types";
+
+type Props = {
+  today: DailyForecast | undefined;
+};
+
+export function UmbrellaSummary({ today }: Props) {
+  const message = getUmbrellaSummary(today);
+  return (
+    <Alert>
+      <Umbrella className="h-4 w-4" />
+      <AlertTitle>本日の傘判定</AlertTitle>
+      <AlertDescription>{message}</AlertDescription>
+    </Alert>
+  );
+}

--- a/src/features/weather-dashboard/components/weather-dashboard-page.tsx
+++ b/src/features/weather-dashboard/components/weather-dashboard-page.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { AlertCircle, Loader2 } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchForecast, WeatherError } from "../lib/weather-client";
+import { useGeolocation } from "../lib/use-geolocation";
+import type {
+  ApiErrorCode,
+  GeocodingResult,
+  WeatherForecast,
+} from "../lib/types";
+import { CurrentWeatherCard } from "./current-weather-card";
+import { DailyForecastList } from "./daily-forecast-list";
+import { ForecastCharts } from "./forecast-charts";
+import { LocationPicker } from "./location-picker";
+import { UmbrellaSummary } from "./umbrella-summary";
+
+type Location = {
+  latitude: number;
+  longitude: number;
+  label: string;
+};
+
+type ErrorState = {
+  message: string;
+  errorCode?: ApiErrorCode;
+} | null;
+
+type ForecastResult = {
+  forecast: WeatherForecast;
+  locationKey: string;
+};
+
+type ErrorResult = {
+  error: NonNullable<ErrorState>;
+  locationKey: string;
+};
+
+function locationKeyOf(location: Location): string {
+  return `${location.latitude.toFixed(4)},${location.longitude.toFixed(4)}`;
+}
+
+export function WeatherDashboardPage() {
+  const geo = useGeolocation();
+  const [manualLocation, setManualLocation] = useState<Location | null>(null);
+  const [forecastResult, setForecastResult] = useState<ForecastResult | null>(null);
+  const [errorResult, setErrorResult] = useState<ErrorResult | null>(null);
+
+  const location: Location | null = useMemo(() => {
+    if (manualLocation) return manualLocation;
+    if (geo.status === "granted" && geo.coords) {
+      return {
+        latitude: geo.coords.latitude,
+        longitude: geo.coords.longitude,
+        label: "現在地",
+      };
+    }
+    return null;
+  }, [manualLocation, geo.status, geo.coords]);
+
+  const currentKey = location ? locationKeyOf(location) : null;
+  const forecast =
+    forecastResult && currentKey === forecastResult.locationKey
+      ? forecastResult.forecast
+      : null;
+  const error =
+    errorResult && currentKey === errorResult.locationKey
+      ? errorResult.error
+      : null;
+  const loading = location !== null && forecast === null && error === null;
+
+  useEffect(() => {
+    if (!location) return;
+    let cancelled = false;
+    const key = locationKeyOf(location);
+    fetchForecast(location.latitude, location.longitude)
+      .then((data) => {
+        if (cancelled) return;
+        setForecastResult({ forecast: data, locationKey: key });
+        setErrorResult(null);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        const err: NonNullable<ErrorState> =
+          e instanceof WeatherError
+            ? { message: e.message, errorCode: e.errorCode }
+            : {
+                message:
+                  e instanceof Error
+                    ? e.message
+                    : "天気情報の取得に失敗しました。",
+              };
+        setErrorResult({ error: err, locationKey: key });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [location]);
+
+  const handleSelectCity = useCallback((result: GeocodingResult) => {
+    const subtitle = [result.admin1, result.country].filter(Boolean).join(", ");
+    setManualLocation({
+      latitude: result.latitude,
+      longitude: result.longitude,
+      label: subtitle ? `${result.name}（${subtitle}）` : result.name,
+    });
+  }, []);
+
+  const handleUseCurrentLocation = useCallback(() => {
+    setManualLocation(null);
+    geo.request();
+  }, [geo]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Weather Dashboard</h1>
+        <p className="mt-2 text-muted-foreground">
+          現在の天気と週間予報を表示します。Open-Meteo APIを使用しています。
+        </p>
+      </div>
+
+      <LocationPicker
+        onSelect={handleSelectCity}
+        onUseCurrentLocation={handleUseCurrentLocation}
+        geolocationDisabled={
+          geo.status === "loading" || geo.status === "unsupported"
+        }
+      />
+
+      {geo.status === "loading" && !location && (
+        <p className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          現在地を取得中...
+        </p>
+      )}
+
+      {geo.status === "denied" && !location && (
+        <Alert>
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>位置情報の取得が許可されていません</AlertTitle>
+          <AlertDescription>
+            都市名で検索するか、ブラウザの設定で位置情報を許可してください。
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {geo.status === "unsupported" && !location && (
+        <Alert>
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>このブラウザでは位置情報を利用できません</AlertTitle>
+          <AlertDescription>都市名で検索してご利用ください。</AlertDescription>
+        </Alert>
+      )}
+
+      {geo.status === "error" && !location && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>位置情報の取得に失敗しました</AlertTitle>
+          <AlertDescription>
+            {geo.errorMessage ?? "都市名で検索してください。"}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {error && (
+        <Alert variant="destructive" role="alert">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>エラー</AlertTitle>
+          <AlertDescription>{error.message}</AlertDescription>
+        </Alert>
+      )}
+
+      {loading && (
+        <div className="space-y-4">
+          <Skeleton className="h-32 w-full" />
+          <Skeleton className="h-60 w-full" />
+          <Skeleton className="h-72 w-full" />
+        </div>
+      )}
+
+      {forecast && location && (
+        <div className="space-y-6">
+          <UmbrellaSummary today={forecast.daily[0]} />
+          <CurrentWeatherCard
+            current={forecast.current}
+            locationLabel={location.label}
+          />
+          <ForecastCharts hourly={forecast.hourly} daily={forecast.daily} />
+          <DailyForecastList daily={forecast.daily} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/weather-dashboard/components/weather-dashboard-page.tsx
+++ b/src/features/weather-dashboard/components/weather-dashboard-page.tsx
@@ -47,6 +47,7 @@ export function WeatherDashboardPage() {
   const [manualLocation, setManualLocation] = useState<Location | null>(null);
   const [forecastResult, setForecastResult] = useState<ForecastResult | null>(null);
   const [errorResult, setErrorResult] = useState<ErrorResult | null>(null);
+  const [refetchToken, setRefetchToken] = useState(0);
 
   const location: Location | null = useMemo(() => {
     if (manualLocation) return manualLocation;
@@ -60,7 +61,9 @@ export function WeatherDashboardPage() {
     return null;
   }, [manualLocation, geo.status, geo.coords]);
 
-  const currentKey = location ? locationKeyOf(location) : null;
+  const currentKey = location
+    ? `${locationKeyOf(location)}#${refetchToken}`
+    : null;
   const forecast =
     forecastResult && currentKey === forecastResult.locationKey
       ? forecastResult.forecast
@@ -74,7 +77,7 @@ export function WeatherDashboardPage() {
   useEffect(() => {
     if (!location) return;
     let cancelled = false;
-    const key = locationKeyOf(location);
+    const key = `${locationKeyOf(location)}#${refetchToken}`;
     fetchForecast(location.latitude, location.longitude)
       .then((data) => {
         if (cancelled) return;
@@ -97,7 +100,7 @@ export function WeatherDashboardPage() {
     return () => {
       cancelled = true;
     };
-  }, [location]);
+  }, [location, refetchToken]);
 
   const handleSelectCity = useCallback((result: GeocodingResult) => {
     const subtitle = [result.admin1, result.country].filter(Boolean).join(", ");
@@ -106,10 +109,12 @@ export function WeatherDashboardPage() {
       longitude: result.longitude,
       label: subtitle ? `${result.name}（${subtitle}）` : result.name,
     });
+    setRefetchToken((token) => token + 1);
   }, []);
 
   const handleUseCurrentLocation = useCallback(() => {
     setManualLocation(null);
+    setRefetchToken((token) => token + 1);
     geo.request();
   }, [geo]);
 

--- a/src/features/weather-dashboard/components/weather-icon.tsx
+++ b/src/features/weather-dashboard/components/weather-icon.tsx
@@ -9,6 +9,7 @@ import {
   CloudSun,
   Sun,
 } from "lucide-react";
+import { weatherIconCategory } from "../lib/weather-summary";
 
 type Props = {
   code: number;
@@ -20,20 +21,24 @@ export function WeatherIcon({ code, className, label }: Props) {
   const ariaProps = label
     ? { "aria-label": label, role: "img" as const }
     : { "aria-hidden": true as const };
-
-  if (code === 0 || code === 1) return <Sun className={className} {...ariaProps} />;
-  if (code === 2) return <CloudSun className={className} {...ariaProps} />;
-  if (code === 3) return <Cloud className={className} {...ariaProps} />;
-  if (code === 45 || code === 48)
-    return <CloudFog className={className} {...ariaProps} />;
-  if (code >= 51 && code <= 57)
-    return <CloudDrizzle className={className} {...ariaProps} />;
-  if ((code >= 61 && code <= 67) || (code >= 80 && code <= 82))
-    return <CloudRain className={className} {...ariaProps} />;
-  if ((code >= 71 && code <= 77) || code === 85 || code === 86)
-    return <CloudSnow className={className} {...ariaProps} />;
-  if (code === 95) return <CloudLightning className={className} {...ariaProps} />;
-  if (code === 96 || code === 99)
-    return <CloudHail className={className} {...ariaProps} />;
-  return <Cloud className={className} {...ariaProps} />;
+  switch (weatherIconCategory(code)) {
+    case "sun":
+      return <Sun className={className} {...ariaProps} />;
+    case "cloudSun":
+      return <CloudSun className={className} {...ariaProps} />;
+    case "cloud":
+      return <Cloud className={className} {...ariaProps} />;
+    case "fog":
+      return <CloudFog className={className} {...ariaProps} />;
+    case "drizzle":
+      return <CloudDrizzle className={className} {...ariaProps} />;
+    case "rain":
+      return <CloudRain className={className} {...ariaProps} />;
+    case "snow":
+      return <CloudSnow className={className} {...ariaProps} />;
+    case "lightning":
+      return <CloudLightning className={className} {...ariaProps} />;
+    case "hail":
+      return <CloudHail className={className} {...ariaProps} />;
+  }
 }

--- a/src/features/weather-dashboard/components/weather-icon.tsx
+++ b/src/features/weather-dashboard/components/weather-icon.tsx
@@ -1,0 +1,39 @@
+import {
+  Cloud,
+  CloudDrizzle,
+  CloudFog,
+  CloudHail,
+  CloudLightning,
+  CloudRain,
+  CloudSnow,
+  CloudSun,
+  Sun,
+} from "lucide-react";
+
+type Props = {
+  code: number;
+  className?: string;
+  label?: string;
+};
+
+export function WeatherIcon({ code, className, label }: Props) {
+  const ariaProps = label
+    ? { "aria-label": label, role: "img" as const }
+    : { "aria-hidden": true as const };
+
+  if (code === 0 || code === 1) return <Sun className={className} {...ariaProps} />;
+  if (code === 2) return <CloudSun className={className} {...ariaProps} />;
+  if (code === 3) return <Cloud className={className} {...ariaProps} />;
+  if (code === 45 || code === 48)
+    return <CloudFog className={className} {...ariaProps} />;
+  if (code >= 51 && code <= 57)
+    return <CloudDrizzle className={className} {...ariaProps} />;
+  if ((code >= 61 && code <= 67) || (code >= 80 && code <= 82))
+    return <CloudRain className={className} {...ariaProps} />;
+  if ((code >= 71 && code <= 77) || code === 85 || code === 86)
+    return <CloudSnow className={className} {...ariaProps} />;
+  if (code === 95) return <CloudLightning className={className} {...ariaProps} />;
+  if (code === 96 || code === 99)
+    return <CloudHail className={className} {...ariaProps} />;
+  return <Cloud className={className} {...ariaProps} />;
+}

--- a/src/features/weather-dashboard/lib/__tests__/use-geolocation.test.ts
+++ b/src/features/weather-dashboard/lib/__tests__/use-geolocation.test.ts
@@ -1,0 +1,106 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useGeolocation } from "../use-geolocation";
+
+type MockGeo = {
+  getCurrentPosition: jest.Mock;
+};
+
+function setNavigatorGeolocation(geolocation: MockGeo | undefined) {
+  Object.defineProperty(global.navigator, "geolocation", {
+    configurable: true,
+    value: geolocation,
+  });
+}
+
+describe("useGeolocation", () => {
+  afterEach(() => {
+    setNavigatorGeolocation(undefined);
+  });
+
+  it("transitions to granted on success", async () => {
+    const getCurrentPosition = jest.fn(
+      (success: PositionCallback) => {
+        success({
+          coords: {
+            latitude: 35.5,
+            longitude: 139.5,
+            accuracy: 10,
+            altitude: null,
+            altitudeAccuracy: null,
+            heading: null,
+            speed: null,
+          },
+          timestamp: Date.now(),
+        } as GeolocationPosition);
+      }
+    );
+    setNavigatorGeolocation({ getCurrentPosition });
+
+    const { result } = renderHook(() => useGeolocation(true));
+
+    await waitFor(() => expect(result.current.status).toBe("granted"));
+    expect(result.current.coords).toEqual({ latitude: 35.5, longitude: 139.5 });
+  });
+
+  it("transitions to denied when permission is denied", async () => {
+    const getCurrentPosition = jest.fn(
+      (_success: PositionCallback, error?: PositionErrorCallback) => {
+        error?.({
+          code: 1,
+          message: "User denied",
+          PERMISSION_DENIED: 1,
+          POSITION_UNAVAILABLE: 2,
+          TIMEOUT: 3,
+        } as GeolocationPositionError);
+      }
+    );
+    setNavigatorGeolocation({ getCurrentPosition });
+
+    const { result } = renderHook(() => useGeolocation(true));
+
+    await waitFor(() => expect(result.current.status).toBe("denied"));
+    expect(result.current.coords).toBeNull();
+    expect(result.current.errorMessage).toBe("User denied");
+  });
+
+  it("transitions to error for non-permission failures", async () => {
+    const getCurrentPosition = jest.fn(
+      (_success: PositionCallback, error?: PositionErrorCallback) => {
+        error?.({
+          code: 2,
+          message: "unavailable",
+          PERMISSION_DENIED: 1,
+          POSITION_UNAVAILABLE: 2,
+          TIMEOUT: 3,
+        } as GeolocationPositionError);
+      }
+    );
+    setNavigatorGeolocation({ getCurrentPosition });
+
+    const { result } = renderHook(() => useGeolocation(true));
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.errorMessage).toBe("unavailable");
+  });
+
+  it("returns 'unsupported' when navigator.geolocation is undefined", () => {
+    setNavigatorGeolocation(undefined);
+
+    const { result } = renderHook(() => useGeolocation(true));
+    expect(result.current.status).toBe("unsupported");
+  });
+
+  it("does not auto-request when autoRequest is false", () => {
+    const getCurrentPosition = jest.fn();
+    setNavigatorGeolocation({ getCurrentPosition });
+
+    const { result } = renderHook(() => useGeolocation(false));
+    expect(getCurrentPosition).not.toHaveBeenCalled();
+    expect(result.current.status).toBe("idle");
+
+    act(() => {
+      result.current.request();
+    });
+    expect(getCurrentPosition).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/weather-dashboard/lib/__tests__/weather-client.test.ts
+++ b/src/features/weather-dashboard/lib/__tests__/weather-client.test.ts
@@ -1,0 +1,111 @@
+import { fetchForecast, searchCities, WeatherError } from "../weather-client";
+
+describe("fetchForecast", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("returns forecast on successful response", async () => {
+    const payload = {
+      timezone: "Asia/Tokyo",
+      current: {
+        time: "2026-04-29T12:00",
+        temperature: 22,
+        humidity: 60,
+        precipitationProbability: 10,
+        windSpeed: 3,
+        weatherCode: 0,
+      },
+      hourly: [],
+      daily: [],
+    };
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(payload),
+    });
+    global.fetch = fetchMock;
+
+    const result = await fetchForecast(35.0, 139.0);
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("mode=forecast"));
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("lat=35"));
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("lon=139"));
+  });
+
+  it("throws WeatherError with errorCode on validation error", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () =>
+        Promise.resolve({
+          error: "緯度・経度の指定が不正です。",
+          errorCode: "VALIDATION_ERROR",
+        }),
+    });
+
+    const error = await fetchForecast(999, 0).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(WeatherError);
+    expect((error as WeatherError).errorCode).toBe("VALIDATION_ERROR");
+    expect((error as WeatherError).message).toBe("緯度・経度の指定が不正です。");
+  });
+
+  it("throws fallback error when response body is not JSON", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: () => Promise.reject(new Error("invalid")),
+    });
+
+    await expect(fetchForecast(0, 0)).rejects.toThrow("リクエストに失敗しました。（502）");
+  });
+});
+
+describe("searchCities", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("returns geocoding results", async () => {
+    const payload = {
+      results: [
+        {
+          id: 1,
+          name: "Tokyo",
+          latitude: 35.68,
+          longitude: 139.76,
+          country: "Japan",
+        },
+      ],
+    };
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(payload),
+    });
+    global.fetch = fetchMock;
+
+    const result = await searchCities("Tokyo");
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("mode=geocode"));
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("q=Tokyo"));
+  });
+
+  it("propagates RATE_LIMITED errorCode", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: () =>
+        Promise.resolve({
+          error: "リクエストが多すぎます。",
+          errorCode: "RATE_LIMITED",
+        }),
+    });
+
+    const error = await searchCities("a".repeat(5)).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(WeatherError);
+    expect((error as WeatherError).errorCode).toBe("RATE_LIMITED");
+  });
+});

--- a/src/features/weather-dashboard/lib/__tests__/weather-summary.test.ts
+++ b/src/features/weather-dashboard/lib/__tests__/weather-summary.test.ts
@@ -1,0 +1,114 @@
+import {
+  Cloud,
+  CloudDrizzle,
+  CloudFog,
+  CloudHail,
+  CloudLightning,
+  CloudRain,
+  CloudSnow,
+  CloudSun,
+  Sun,
+} from "lucide-react";
+import {
+  describeWeatherCode,
+  getUmbrellaSummary,
+  getWeatherIcon,
+  UMBRELLA_THRESHOLD,
+} from "../weather-summary";
+import type { DailyForecast } from "../types";
+
+function makeDay(probability: number): DailyForecast {
+  return {
+    date: "2026-04-29",
+    weatherCode: 0,
+    temperatureMax: 20,
+    temperatureMin: 12,
+    precipitationProbabilityMax: probability,
+  };
+}
+
+describe("getUmbrellaSummary", () => {
+  it("returns fallback message when today is undefined", () => {
+    expect(getUmbrellaSummary(undefined)).toContain("取得できませんでした");
+  });
+
+  it("returns 'umbrella required' for very high probability (>=80)", () => {
+    const message = getUmbrellaSummary(makeDay(85));
+    expect(message).toContain("85%");
+    expect(message).toContain("傘を必ず");
+  });
+
+  it("recommends umbrella at the threshold (50)", () => {
+    const message = getUmbrellaSummary(makeDay(UMBRELLA_THRESHOLD));
+    expect(message).toContain(`${UMBRELLA_THRESHOLD}%`);
+    expect(message).toContain("傘を持って");
+  });
+
+  it("suggests folding umbrella between 20 and threshold", () => {
+    const message = getUmbrellaSummary(makeDay(30));
+    expect(message).toContain("30%");
+    expect(message).toContain("折りたたみ");
+  });
+
+  it("says umbrella is unnecessary below 20", () => {
+    const message = getUmbrellaSummary(makeDay(10));
+    expect(message).toContain("10%");
+    expect(message).toContain("不要");
+  });
+
+  it("handles 0% as no umbrella", () => {
+    const message = getUmbrellaSummary(makeDay(0));
+    expect(message).toContain("不要");
+  });
+
+  it("handles 100% as strongly recommended", () => {
+    const message = getUmbrellaSummary(makeDay(100));
+    expect(message).toContain("傘を必ず");
+  });
+});
+
+describe("describeWeatherCode", () => {
+  it.each([
+    [0, "快晴"],
+    [3, "曇り"],
+    [63, "雨"],
+    [95, "雷雨"],
+  ])("describes code %i as %s", (code, expected) => {
+    expect(describeWeatherCode(code)).toBe(expected);
+  });
+
+  it("returns '不明' for unknown code", () => {
+    expect(describeWeatherCode(9999)).toBe("不明");
+  });
+});
+
+describe("getWeatherIcon", () => {
+  it.each([
+    [0, Sun],
+    [1, Sun],
+    [2, CloudSun],
+    [3, Cloud],
+    [45, CloudFog],
+    [48, CloudFog],
+    [51, CloudDrizzle],
+    [55, CloudDrizzle],
+    [57, CloudDrizzle],
+    [61, CloudRain],
+    [65, CloudRain],
+    [80, CloudRain],
+    [82, CloudRain],
+    [71, CloudSnow],
+    [75, CloudSnow],
+    [85, CloudSnow],
+    [86, CloudSnow],
+    [95, CloudLightning],
+    [96, CloudHail],
+    [99, CloudHail],
+  ])("maps weather code %i to the expected icon", (code, expected) => {
+    expect(getWeatherIcon(code)).toBe(expected);
+  });
+
+  it("falls back to Cloud for unknown codes", () => {
+    expect(getWeatherIcon(9999)).toBe(Cloud);
+  });
+});

--- a/src/features/weather-dashboard/lib/types.ts
+++ b/src/features/weather-dashboard/lib/types.ts
@@ -1,0 +1,48 @@
+export type ApiErrorCode =
+  | "VALIDATION_ERROR"
+  | "RATE_LIMITED"
+  | "UPSTREAM_ERROR"
+  | "SERVER_ERROR";
+
+export type GeocodingResult = {
+  id: number;
+  name: string;
+  latitude: number;
+  longitude: number;
+  country?: string;
+  admin1?: string;
+};
+
+export type GeocodingResponse = {
+  results: GeocodingResult[];
+};
+
+export type CurrentWeather = {
+  temperature: number;
+  humidity: number;
+  precipitationProbability: number;
+  windSpeed: number;
+  weatherCode: number;
+  time: string;
+};
+
+export type HourlyPoint = {
+  time: string;
+  temperature: number;
+  precipitationProbability: number;
+};
+
+export type DailyForecast = {
+  date: string;
+  weatherCode: number;
+  temperatureMax: number;
+  temperatureMin: number;
+  precipitationProbabilityMax: number;
+};
+
+export type WeatherForecast = {
+  timezone: string;
+  current: CurrentWeather;
+  hourly: HourlyPoint[];
+  daily: DailyForecast[];
+};

--- a/src/features/weather-dashboard/lib/use-geolocation.ts
+++ b/src/features/weather-dashboard/lib/use-geolocation.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export type GeolocationStatus =
+  | "idle"
+  | "loading"
+  | "granted"
+  | "denied"
+  | "unsupported"
+  | "error";
+
+export type GeolocationState = {
+  status: GeolocationStatus;
+  coords: { latitude: number; longitude: number } | null;
+  errorMessage: string | null;
+};
+
+const POSITION_OPTIONS: PositionOptions = {
+  enableHighAccuracy: false,
+  maximumAge: 5 * 60_000,
+  timeout: 10_000,
+};
+
+function isSupported(): boolean {
+  return typeof navigator !== "undefined" && Boolean(navigator.geolocation);
+}
+
+function initialState(autoRequest: boolean): GeolocationState {
+  if (!isSupported()) {
+    return { status: "unsupported", coords: null, errorMessage: null };
+  }
+  return autoRequest
+    ? { status: "loading", coords: null, errorMessage: null }
+    : { status: "idle", coords: null, errorMessage: null };
+}
+
+export function useGeolocation(autoRequest = true): GeolocationState & {
+  request: () => void;
+} {
+  const [state, setState] = useState<GeolocationState>(() =>
+    initialState(autoRequest)
+  );
+
+  const request = useCallback(() => {
+    if (!isSupported()) {
+      setState({ status: "unsupported", coords: null, errorMessage: null });
+      return;
+    }
+    setState({ status: "loading", coords: null, errorMessage: null });
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        setState({
+          status: "granted",
+          coords: {
+            latitude: position.coords.latitude,
+            longitude: position.coords.longitude,
+          },
+          errorMessage: null,
+        });
+      },
+      (err) => {
+        const denied = err.code === err.PERMISSION_DENIED;
+        setState({
+          status: denied ? "denied" : "error",
+          coords: null,
+          errorMessage: err.message,
+        });
+      },
+      POSITION_OPTIONS
+    );
+  }, []);
+
+  useEffect(() => {
+    if (!autoRequest || !isSupported()) return;
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        setState({
+          status: "granted",
+          coords: {
+            latitude: position.coords.latitude,
+            longitude: position.coords.longitude,
+          },
+          errorMessage: null,
+        });
+      },
+      (err) => {
+        const denied = err.code === err.PERMISSION_DENIED;
+        setState({
+          status: denied ? "denied" : "error",
+          coords: null,
+          errorMessage: err.message,
+        });
+      },
+      POSITION_OPTIONS
+    );
+  }, [autoRequest]);
+
+  return { ...state, request };
+}

--- a/src/features/weather-dashboard/lib/use-geolocation.ts
+++ b/src/features/weather-dashboard/lib/use-geolocation.ts
@@ -35,6 +35,32 @@ function initialState(autoRequest: boolean): GeolocationState {
     : { status: "idle", coords: null, errorMessage: null };
 }
 
+function fetchGeolocation(
+  setState: (next: GeolocationState) => void
+): void {
+  navigator.geolocation.getCurrentPosition(
+    (position) => {
+      setState({
+        status: "granted",
+        coords: {
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude,
+        },
+        errorMessage: null,
+      });
+    },
+    (err) => {
+      const denied = err.code === err.PERMISSION_DENIED;
+      setState({
+        status: denied ? "denied" : "error",
+        coords: null,
+        errorMessage: err.message,
+      });
+    },
+    POSITION_OPTIONS
+  );
+}
+
 export function useGeolocation(autoRequest = true): GeolocationState & {
   request: () => void;
 } {
@@ -48,52 +74,12 @@ export function useGeolocation(autoRequest = true): GeolocationState & {
       return;
     }
     setState({ status: "loading", coords: null, errorMessage: null });
-    navigator.geolocation.getCurrentPosition(
-      (position) => {
-        setState({
-          status: "granted",
-          coords: {
-            latitude: position.coords.latitude,
-            longitude: position.coords.longitude,
-          },
-          errorMessage: null,
-        });
-      },
-      (err) => {
-        const denied = err.code === err.PERMISSION_DENIED;
-        setState({
-          status: denied ? "denied" : "error",
-          coords: null,
-          errorMessage: err.message,
-        });
-      },
-      POSITION_OPTIONS
-    );
+    fetchGeolocation(setState);
   }, []);
 
   useEffect(() => {
     if (!autoRequest || !isSupported()) return;
-    navigator.geolocation.getCurrentPosition(
-      (position) => {
-        setState({
-          status: "granted",
-          coords: {
-            latitude: position.coords.latitude,
-            longitude: position.coords.longitude,
-          },
-          errorMessage: null,
-        });
-      },
-      (err) => {
-        const denied = err.code === err.PERMISSION_DENIED;
-        setState({
-          status: denied ? "denied" : "error",
-          coords: null,
-          errorMessage: err.message,
-        });
-      },
-      POSITION_OPTIONS
-    );
+    fetchGeolocation(setState);
   }, [autoRequest]);
 
   return { ...state, request };

--- a/src/features/weather-dashboard/lib/weather-client.ts
+++ b/src/features/weather-dashboard/lib/weather-client.ts
@@ -1,0 +1,43 @@
+import type {
+  ApiErrorCode,
+  GeocodingResponse,
+  WeatherForecast,
+} from "./types";
+
+export class WeatherError extends Error {
+  readonly errorCode: ApiErrorCode | undefined;
+
+  constructor(message: string, errorCode?: ApiErrorCode) {
+    super(message);
+    this.name = "WeatherError";
+    this.errorCode = errorCode;
+  }
+}
+
+async function request<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    const message =
+      body?.error ?? `リクエストに失敗しました。（${res.status}）`;
+    throw new WeatherError(message, body?.errorCode);
+  }
+  return res.json() as Promise<T>;
+}
+
+export function fetchForecast(
+  latitude: number,
+  longitude: number
+): Promise<WeatherForecast> {
+  const params = new URLSearchParams({
+    mode: "forecast",
+    lat: String(latitude),
+    lon: String(longitude),
+  });
+  return request<WeatherForecast>(`/api/weather?${params.toString()}`);
+}
+
+export function searchCities(query: string): Promise<GeocodingResponse> {
+  const params = new URLSearchParams({ mode: "geocode", q: query });
+  return request<GeocodingResponse>(`/api/weather?${params.toString()}`);
+}

--- a/src/features/weather-dashboard/lib/weather-summary.ts
+++ b/src/features/weather-dashboard/lib/weather-summary.ts
@@ -66,15 +66,42 @@ export function describeWeatherCode(code: number): string {
   return WEATHER_CODE_LABELS[code] ?? "不明";
 }
 
+export type WeatherIconCategory =
+  | "sun"
+  | "cloudSun"
+  | "cloud"
+  | "fog"
+  | "drizzle"
+  | "rain"
+  | "snow"
+  | "lightning"
+  | "hail";
+
+export function weatherIconCategory(code: number): WeatherIconCategory {
+  if (code === 0 || code === 1) return "sun";
+  if (code === 2) return "cloudSun";
+  if (code === 3) return "cloud";
+  if (code === 45 || code === 48) return "fog";
+  if (code >= 51 && code <= 57) return "drizzle";
+  if ((code >= 61 && code <= 67) || (code >= 80 && code <= 82)) return "rain";
+  if ((code >= 71 && code <= 77) || code === 85 || code === 86) return "snow";
+  if (code === 95) return "lightning";
+  if (code === 96 || code === 99) return "hail";
+  return "cloud";
+}
+
+const ICON_BY_CATEGORY: Record<WeatherIconCategory, LucideIcon> = {
+  sun: Sun,
+  cloudSun: CloudSun,
+  cloud: Cloud,
+  fog: CloudFog,
+  drizzle: CloudDrizzle,
+  rain: CloudRain,
+  snow: CloudSnow,
+  lightning: CloudLightning,
+  hail: CloudHail,
+};
+
 export function getWeatherIcon(code: number): LucideIcon {
-  if (code === 0 || code === 1) return Sun;
-  if (code === 2) return CloudSun;
-  if (code === 3) return Cloud;
-  if (code === 45 || code === 48) return CloudFog;
-  if (code >= 51 && code <= 57) return CloudDrizzle;
-  if ((code >= 61 && code <= 67) || (code >= 80 && code <= 82)) return CloudRain;
-  if ((code >= 71 && code <= 77) || code === 85 || code === 86) return CloudSnow;
-  if (code === 95) return CloudLightning;
-  if (code === 96 || code === 99) return CloudHail;
-  return Cloud;
+  return ICON_BY_CATEGORY[weatherIconCategory(code)];
 }

--- a/src/features/weather-dashboard/lib/weather-summary.ts
+++ b/src/features/weather-dashboard/lib/weather-summary.ts
@@ -1,0 +1,80 @@
+import {
+  Cloud,
+  CloudDrizzle,
+  CloudFog,
+  CloudHail,
+  CloudLightning,
+  CloudRain,
+  CloudSnow,
+  CloudSun,
+  Sun,
+  type LucideIcon,
+} from "lucide-react";
+import type { DailyForecast } from "./types";
+
+export const UMBRELLA_THRESHOLD = 50;
+
+export function getUmbrellaSummary(today: DailyForecast | undefined): string {
+  if (!today) {
+    return "本日の予報を取得できませんでした。";
+  }
+  const probability = today.precipitationProbabilityMax;
+  if (probability >= 80) {
+    return `本日は雨の可能性が非常に高いです（降水確率 ${probability}%）。傘を必ず持って出かけましょう。`;
+  }
+  if (probability >= UMBRELLA_THRESHOLD) {
+    return `本日は雨が降るかもしれません（降水確率 ${probability}%）。傘を持って出かけると安心です。`;
+  }
+  if (probability >= 20) {
+    return `本日の降水確率は ${probability}% です。念のため折りたたみ傘があると安心です。`;
+  }
+  return `本日の降水確率は ${probability}% です。傘は不要そうです。`;
+}
+
+const WEATHER_CODE_LABELS: Record<number, string> = {
+  0: "快晴",
+  1: "晴れ",
+  2: "薄曇り",
+  3: "曇り",
+  45: "霧",
+  48: "霧氷",
+  51: "霧雨（弱）",
+  53: "霧雨",
+  55: "霧雨（強）",
+  56: "着氷性の霧雨",
+  57: "着氷性の強い霧雨",
+  61: "雨（弱）",
+  63: "雨",
+  65: "雨（強）",
+  66: "凍雨",
+  67: "強い凍雨",
+  71: "雪（弱）",
+  73: "雪",
+  75: "雪（強）",
+  77: "霧雪",
+  80: "にわか雨（弱）",
+  81: "にわか雨",
+  82: "激しいにわか雨",
+  85: "にわか雪（弱）",
+  86: "にわか雪",
+  95: "雷雨",
+  96: "雷雨と弱いひょう",
+  99: "雷雨と強いひょう",
+};
+
+export function describeWeatherCode(code: number): string {
+  return WEATHER_CODE_LABELS[code] ?? "不明";
+}
+
+export function getWeatherIcon(code: number): LucideIcon {
+  if (code === 0 || code === 1) return Sun;
+  if (code === 2) return CloudSun;
+  if (code === 3) return Cloud;
+  if (code === 45 || code === 48) return CloudFog;
+  if (code >= 51 && code <= 57) return CloudDrizzle;
+  if ((code >= 61 && code <= 67) || (code >= 80 && code <= 82)) return CloudRain;
+  if ((code >= 71 && code <= 77) || code === 85 || code === 86) return CloudSnow;
+  if (code === 95) return CloudLightning;
+  if (code === 96 || code === 99) return CloudHail;
+  return Cloud;
+}


### PR DESCRIPTION
## Summary

- Open-Meteo API を使った天気ダッシュボードツールを `src/features/weather-dashboard/` 配下に新規追加
- 現在地（Geolocation API）または都市名検索（Open-Meteo Geocoding）で位置を選択
- 現在の天気・時間別/週間予報グラフ（タブで切り替え、ComposedChart で気温＋降水確率の同時表示）・週間予報リスト（ヘッダー付き）・傘判定 Alert を表示
- WMO weather code に応じた lucide-react アイコン（Sun/Cloud/CloudRain など）を現在天気・週間予報リストに表示
- shadcn/ui chart コンポーネントを `npx shadcn@latest add chart` で導入（recharts 依存追加）
- API は `src/app/api/weather/route.ts` 経由。rate limit + 入力バリデーションを実装
- ホーム画面の `CATEGORIES` に新カテゴリ `external-api`（外部API活用）を追加
- 純粋ロジック・fetch ラッパー・geolocation hook の Jest テスト 43件を追加（全 509件 PASS）

**PR size 注記**: 新規ディレクトリ・ファイル中心の機能追加のため、shared conventions の例外条項により規模超過（20 files / +2301）を許容。`package-lock.json`（+376）と `src/components/ui/chart.tsx`（+374、shadcn 自動生成）を除くと実質 18 files / 約 1,550 行。

Closes #34

## Test plan

- [ ] `/tools/weather-dashboard` 画面で位置情報の許可ダイアログが表示される
- [ ] 許可した場合、現在地の天気・時間別/週間予報グラフ・週間予報リスト・傘判定が表示される
- [ ] 拒否/未対応の場合、都市名検索 UI で東京等を選択すると同じ画面が表示できる
- [ ] グラフのタブ切り替え（時間別 ↔ 週間）で正しく内容が切り替わる
- [ ] 週間予報リストのヘッダー（日付・天気・降水・気温）と各列の値が縦に揃って見える
- [ ] ダーク／ライトテーマ両方でレイアウト崩れがない
- [ ] `npm run lint` / `npm run test` / `npm run build` がローカルで通る
- [ ] ホーム画面に「外部API活用」セクションが追加され、Weather Dashboard カードが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)