### PR TITLE
feat: 為替レート計算機ツールを追加 (#35)

### DIFF
--- a/src/app/api/exchange-rate/route.ts
+++ b/src/app/api/exchange-rate/route.ts
@@ -165,7 +165,21 @@ async function fetchUpstream(url: URL, failureMessage: string): Promise<Upstream
   }
 
   if (!upstream.ok) {
-    if (upstream.status >= 400 && upstream.status < 500) {
+    if (upstream.status === 429) {
+      return {
+        ok: false,
+        errorResponse: NextResponse.json(
+          {
+            error: "為替レートサービスのレート制限に達しました。しばらく経ってから再度お試しください。",
+            errorCode: "RATE_LIMITED",
+          },
+          { status: 429 }
+        ),
+      };
+    }
+    if (upstream.status === 404 || upstream.status === 422) {
+      // Frankfurter は不明な通貨コードや不正な日付に対して 404/422 を返す。
+      // クライアント側で形式検証は済んでいるので、上流が「データが存在しない」と判断したものとして扱う。
       const body = await upstream.json().catch(() => null);
       const message =
         typeof body === "object" && body !== null && "message" in body

--- a/src/app/api/exchange-rate/route.ts
+++ b/src/app/api/exchange-rate/route.ts
@@ -1,0 +1,214 @@
+import { NextResponse } from "next/server";
+import { createRateLimit } from "@/lib/rate-limit";
+import { getClientIp, rateLimitResponse } from "@/lib/api-helpers";
+import type {
+  CurrencyMap,
+  LatestRates,
+  Timeseries,
+} from "@/features/exchange-rate-calculator/lib/types";
+
+const FRANKFURTER_BASE_URL = "https://api.frankfurter.app";
+const CURRENCY_CODE_PATTERN = /^[A-Z]{3}$/;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_TARGETS = 10;
+const MAX_RANGE_DAYS = 366;
+
+const rateLimit = createRateLimit({ limit: 30, windowMs: 60_000 });
+
+export async function GET(request: Request) {
+  const ip = getClientIp(request);
+  if (ip !== "unknown") {
+    const result = rateLimit.check(ip);
+    if (!result.allowed) {
+      return rateLimitResponse(result.retryAfterMs);
+    }
+  }
+
+  const { searchParams } = new URL(request.url);
+  const mode = searchParams.get("mode");
+
+  if (mode === "currencies") {
+    return handleCurrencies();
+  }
+  if (mode === "latest") {
+    return handleLatest(searchParams);
+  }
+  if (mode === "timeseries") {
+    return handleTimeseries(searchParams);
+  }
+  return NextResponse.json(
+    {
+      error: "mode は currencies / latest / timeseries のいずれかを指定してください。",
+      errorCode: "VALIDATION_ERROR",
+    },
+    { status: 400 }
+  );
+}
+
+async function handleCurrencies(): Promise<Response> {
+  const url = new URL(`${FRANKFURTER_BASE_URL}/currencies`);
+
+  const upstream = await fetchUpstream(url, "通貨一覧の取得に失敗しました。");
+  if (!upstream.ok) return upstream.errorResponse;
+
+  const raw = (await upstream.response.json()) as CurrencyMap;
+  return NextResponse.json(raw);
+}
+
+async function handleLatest(params: URLSearchParams): Promise<Response> {
+  const from = params.get("from")?.toUpperCase() ?? "";
+  const toRaw = params.get("to")?.toUpperCase() ?? "";
+
+  if (!CURRENCY_CODE_PATTERN.test(from)) {
+    return validationError("from は3文字の通貨コードを指定してください。");
+  }
+
+  const targets = toRaw.split(",").map((s) => s.trim()).filter(Boolean);
+  if (targets.length === 0 || targets.length > MAX_TARGETS) {
+    return validationError(
+      `to は1〜${MAX_TARGETS}個の通貨コードをカンマ区切りで指定してください。`
+    );
+  }
+  if (targets.some((t) => !CURRENCY_CODE_PATTERN.test(t))) {
+    return validationError("to に不正な通貨コードが含まれています。");
+  }
+  if (targets.includes(from)) {
+    return validationError("from と同じ通貨を to に含めることはできません。");
+  }
+
+  const url = new URL(`${FRANKFURTER_BASE_URL}/latest`);
+  url.searchParams.set("from", from);
+  url.searchParams.set("to", targets.join(","));
+
+  const upstream = await fetchUpstream(url, "為替レートの取得に失敗しました。");
+  if (!upstream.ok) return upstream.errorResponse;
+
+  const raw = (await upstream.response.json()) as FrankfurterLatestResponse;
+  const response: LatestRates = {
+    base: raw.base,
+    date: raw.date,
+    rates: raw.rates,
+  };
+  return NextResponse.json(response);
+}
+
+async function handleTimeseries(params: URLSearchParams): Promise<Response> {
+  const from = params.get("from")?.toUpperCase() ?? "";
+  const to = params.get("to")?.toUpperCase() ?? "";
+  const start = params.get("start") ?? "";
+  const end = params.get("end") ?? "";
+
+  if (!CURRENCY_CODE_PATTERN.test(from) || !CURRENCY_CODE_PATTERN.test(to)) {
+    return validationError("from / to は3文字の通貨コードを指定してください。");
+  }
+  if (from === to) {
+    return validationError("from と to は異なる通貨を指定してください。");
+  }
+  if (!DATE_PATTERN.test(start) || !DATE_PATTERN.test(end)) {
+    return validationError("start / end は YYYY-MM-DD 形式で指定してください。");
+  }
+
+  const startMs = Date.parse(`${start}T00:00:00Z`);
+  const endMs = Date.parse(`${end}T00:00:00Z`);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || startMs > endMs) {
+    return validationError("start / end の日付が不正です。");
+  }
+  const rangeDays = Math.floor((endMs - startMs) / 86_400_000);
+  if (rangeDays > MAX_RANGE_DAYS) {
+    return validationError(
+      `期間は最大${MAX_RANGE_DAYS}日までを指定してください。`
+    );
+  }
+
+  const url = new URL(`${FRANKFURTER_BASE_URL}/${start}..${end}`);
+  url.searchParams.set("from", from);
+  url.searchParams.set("to", to);
+
+  const upstream = await fetchUpstream(url, "レート推移の取得に失敗しました。");
+  if (!upstream.ok) return upstream.errorResponse;
+
+  const raw = (await upstream.response.json()) as FrankfurterTimeseriesResponse;
+  const points = Object.entries(raw.rates ?? {})
+    .map(([date, rateMap]) => ({
+      date,
+      rate: rateMap?.[to] ?? Number.NaN,
+    }))
+    .filter((p) => Number.isFinite(p.rate))
+    .sort((a, b) => (a.date < b.date ? -1 : 1));
+
+  const response: Timeseries = {
+    base: raw.base,
+    target: to,
+    start: raw.start_date ?? start,
+    end: raw.end_date ?? end,
+    points,
+  };
+  return NextResponse.json(response);
+}
+
+type UpstreamResult =
+  | { ok: true; response: Response }
+  | { ok: false; errorResponse: Response };
+
+async function fetchUpstream(url: URL, failureMessage: string): Promise<UpstreamResult> {
+  let upstream: Response;
+  try {
+    upstream = await fetch(url, { headers: { Accept: "application/json" } });
+  } catch {
+    return {
+      ok: false,
+      errorResponse: NextResponse.json(
+        { error: "為替レートサービスに接続できませんでした。", errorCode: "UPSTREAM_ERROR" },
+        { status: 502 }
+      ),
+    };
+  }
+
+  if (!upstream.ok) {
+    if (upstream.status >= 400 && upstream.status < 500) {
+      const body = await upstream.json().catch(() => null);
+      const message =
+        typeof body === "object" && body !== null && "message" in body
+          ? String((body as { message?: unknown }).message ?? failureMessage)
+          : failureMessage;
+      return {
+        ok: false,
+        errorResponse: NextResponse.json(
+          { error: message, errorCode: "VALIDATION_ERROR" },
+          { status: 400 }
+        ),
+      };
+    }
+    return {
+      ok: false,
+      errorResponse: NextResponse.json(
+        { error: failureMessage, errorCode: "UPSTREAM_ERROR" },
+        { status: 502 }
+      ),
+    };
+  }
+
+  return { ok: true, response: upstream };
+}
+
+function validationError(message: string): Response {
+  return NextResponse.json(
+    { error: message, errorCode: "VALIDATION_ERROR" },
+    { status: 400 }
+  );
+}
+
+type FrankfurterLatestResponse = {
+  amount: number;
+  base: string;
+  date: string;
+  rates: Record<string, number>;
+};
+
+type FrankfurterTimeseriesResponse = {
+  amount: number;
+  base: string;
+  start_date?: string;
+  end_date?: string;
+  rates?: Record<string, Record<string, number>>;
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, ArrowLeftRight, Braces, Calculator, Clock, Cloud, FileText, Fingerprint, FileDiff, Languages, Palette, Package, QrCode, Regex, Timer, Type, type LucideIcon } from "lucide-react";
+import { ArrowRight, ArrowLeftRight, Braces, Calculator, Clock, Cloud, Coins, FileText, Fingerprint, FileDiff, Languages, Palette, Package, QrCode, Regex, Timer, Type, type LucideIcon } from "lucide-react";
 import {
   Card,
   CardHeader,
@@ -130,6 +130,13 @@ const tools: Tool[] = [
     description: "現在地または都市名検索で現在の天気・時間別気温・週間予報を表示",
     href: "/tools/weather-dashboard",
     icon: Cloud,
+    category: "external-api",
+  },
+  {
+    name: "Exchange Rate Calculator",
+    description: "ECB公表の日次為替レートで通貨変換、お気に入り通貨ペア・30日推移グラフ",
+    href: "/tools/exchange-rate-calculator",
+    icon: Coins,
     category: "external-api",
   },
 ];

--- a/src/app/tools/exchange-rate-calculator/page.tsx
+++ b/src/app/tools/exchange-rate-calculator/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
 import { ExchangeRateCalculatorPage } from "@/features/exchange-rate-calculator/components/exchange-rate-calculator-page";
+
+export const metadata: Metadata = {
+  title: "Exchange Rate Calculator - Personal Tools",
+  description:
+    "ECB公表の日次為替レートで通貨変換、お気に入り通貨ペア・30日推移グラフ",
+};
 
 export default function Page() {
   return <ExchangeRateCalculatorPage />;

--- a/src/app/tools/exchange-rate-calculator/page.tsx
+++ b/src/app/tools/exchange-rate-calculator/page.tsx
@@ -1,0 +1,5 @@
+import { ExchangeRateCalculatorPage } from "@/features/exchange-rate-calculator/components/exchange-rate-calculator-page";
+
+export default function Page() {
+  return <ExchangeRateCalculatorPage />;
+}

--- a/src/features/exchange-rate-calculator/components/converter-panel.tsx
+++ b/src/features/exchange-rate-calculator/components/converter-panel.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import { ArrowLeftRight, ChevronDown, ChevronUp, Plus, Star, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { formatAmount, formatRate } from "../lib/calculator";
+import type { CurrencyCode, CurrencyMap } from "../lib/types";
+
+type ConversionRow = {
+  currency: CurrencyCode;
+  rate: number | undefined;
+  converted: number | null;
+};
+
+type Props = {
+  amount: string;
+  onAmountChange: (value: string) => void;
+  base: CurrencyCode;
+  onBaseChange: (currency: CurrencyCode) => void;
+  primaryTarget: CurrencyCode;
+  onPrimaryTargetChange: (currency: CurrencyCode) => void;
+  targets: CurrencyCode[];
+  onAddTarget: (currency: CurrencyCode) => void;
+  onRemoveTarget: (currency: CurrencyCode) => void;
+  onMoveTarget: (currency: CurrencyCode, direction: "up" | "down") => void;
+  onSwap: () => void;
+  conversions: ConversionRow[];
+  ratesDate: string | null;
+  ratesLoading: boolean;
+  currencies: CurrencyMap | null;
+  isFavorite: boolean;
+  onToggleFavorite: () => void;
+};
+
+export function ConverterPanel({
+  amount,
+  onAmountChange,
+  base,
+  onBaseChange,
+  primaryTarget,
+  onPrimaryTargetChange,
+  targets,
+  onAddTarget,
+  onRemoveTarget,
+  onMoveTarget,
+  onSwap,
+  conversions,
+  ratesDate,
+  ratesLoading,
+  currencies,
+  isFavorite,
+  onToggleFavorite,
+}: Props) {
+  const currencyEntries = currencies
+    ? Object.entries(currencies).sort(([a], [b]) => a.localeCompare(b))
+    : [];
+  const addCandidates = currencyEntries.filter(
+    ([code]) => code !== base && !targets.includes(code)
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle>金額を換算</CardTitle>
+          <Button
+            type="button"
+            variant={isFavorite ? "default" : "outline"}
+            size="sm"
+            onClick={onToggleFavorite}
+            disabled={base === primaryTarget}
+            aria-label={isFavorite ? "お気に入りから削除" : "お気に入りに追加"}
+            aria-pressed={isFavorite}
+          >
+            <Star
+              className="h-4 w-4"
+              fill={isFavorite ? "currentColor" : "none"}
+              aria-hidden="true"
+            />
+            <span className="ml-1 hidden sm:inline">
+              {isFavorite ? "お気に入り済み" : "お気に入り"}
+            </span>
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid gap-4 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
+          <div className="space-y-2">
+            <Label htmlFor="exchange-amount">金額</Label>
+            <Input
+              id="exchange-amount"
+              type="number"
+              inputMode="decimal"
+              value={amount}
+              onChange={(e) => onAmountChange(e.target.value)}
+              min={0}
+              step="any"
+              placeholder="0"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="exchange-base">基準通貨</Label>
+            <CurrencySelect
+              id="exchange-base"
+              value={base}
+              onValueChange={onBaseChange}
+              currencies={currencyEntries}
+              excluded={[]}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="exchange-primary">主要な変換先</Label>
+            <div className="flex gap-2">
+              <CurrencySelect
+                id="exchange-primary"
+                value={primaryTarget}
+                onValueChange={onPrimaryTargetChange}
+                currencies={currencyEntries}
+                excluded={[base]}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={onSwap}
+                disabled={base === primaryTarget}
+                aria-label="基準通貨と主要な変換先を入れ替え"
+              >
+                <ArrowLeftRight className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <Label>変換結果</Label>
+            {ratesDate && (
+              <span className="text-xs text-muted-foreground">基準日: {ratesDate}</span>
+            )}
+          </div>
+          {ratesLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+            </div>
+          ) : conversions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              変換先を追加してください。
+            </p>
+          ) : (
+            <ul className="divide-y rounded-md border">
+              {conversions.map((row, index) => (
+                <li
+                  key={row.currency}
+                  className="flex items-center justify-between gap-3 px-3 py-2"
+                >
+                  <div className="flex flex-1 items-center gap-2 min-w-0">
+                    <span className="font-mono text-sm font-semibold">{row.currency}</span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      {currencies?.[row.currency] ?? ""}
+                    </span>
+                  </div>
+                  <div className="text-right">
+                    <div className="font-mono text-sm font-semibold tabular-nums">
+                      {row.converted !== null
+                        ? formatAmount(row.converted, row.currency)
+                        : "—"}
+                    </div>
+                    <div className="text-xs text-muted-foreground tabular-nums">
+                      1 {base} = {row.rate !== undefined ? formatRate(row.rate) : "—"} {row.currency}
+                    </div>
+                  </div>
+                  <div className="flex items-center">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => onMoveTarget(row.currency, "up")}
+                      disabled={index === 0}
+                      aria-label={`${row.currency} を上へ移動`}
+                    >
+                      <ChevronUp className="h-4 w-4" aria-hidden="true" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => onMoveTarget(row.currency, "down")}
+                      disabled={index === conversions.length - 1}
+                      aria-label={`${row.currency} を下へ移動`}
+                    >
+                      <ChevronDown className="h-4 w-4" aria-hidden="true" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => onRemoveTarget(row.currency)}
+                      aria-label={`${row.currency} を削除`}
+                    >
+                      <X className="h-4 w-4" aria-hidden="true" />
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label>変換先を追加</Label>
+          <AddCurrencyControl
+            candidates={addCandidates}
+            onAdd={onAddTarget}
+            disabled={!currencies}
+          />
+          <CurrentTargets targets={targets} onRemove={onRemoveTarget} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+type CurrencySelectProps = {
+  id?: string;
+  value: CurrencyCode;
+  onValueChange: (value: CurrencyCode) => void;
+  currencies: Array<[string, string]>;
+  excluded: CurrencyCode[];
+};
+
+function CurrencySelect({ id, value, onValueChange, currencies, excluded }: CurrencySelectProps) {
+  const filtered = currencies.filter(([code]) => !excluded.includes(code));
+  const items = filtered.length > 0 ? filtered : currencies;
+  return (
+    <Select value={value} onValueChange={onValueChange}>
+      <SelectTrigger id={id} className="w-full">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {items.map(([code, name]) => (
+          <SelectItem key={code} value={code}>
+            <span className="font-mono">{code}</span>
+            <span className="ml-2 text-muted-foreground">{name}</span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+type AddCurrencyControlProps = {
+  candidates: Array<[string, string]>;
+  onAdd: (code: CurrencyCode) => void;
+  disabled: boolean;
+};
+
+function AddCurrencyControl({ candidates, onAdd, disabled }: AddCurrencyControlProps) {
+  return (
+    <Select
+      value=""
+      onValueChange={(value) => {
+        if (value) onAdd(value);
+      }}
+      disabled={disabled || candidates.length === 0}
+    >
+      <SelectTrigger className="w-full sm:w-72">
+        <Plus className="h-4 w-4" aria-hidden="true" />
+        <SelectValue placeholder="通貨を選択して追加" />
+      </SelectTrigger>
+      <SelectContent position="popper">
+        {candidates.map(([code, name]) => (
+          <SelectItem key={code} value={code}>
+            <span className="font-mono">{code}</span>
+            <span className="ml-2 text-muted-foreground">{name}</span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function CurrentTargets({
+  targets,
+  onRemove,
+}: {
+  targets: CurrencyCode[];
+  onRemove: (code: CurrencyCode) => void;
+}) {
+  if (targets.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-2">
+      {targets.map((code) => (
+        <Badge key={code} variant="secondary" className="gap-1 font-mono">
+          {code}
+          <button
+            type="button"
+            onClick={() => onRemove(code)}
+            aria-label={`${code} を削除`}
+            className="ml-0.5 inline-flex items-center justify-center rounded-sm hover:bg-muted-foreground/20"
+          >
+            <X className="h-3 w-3" aria-hidden="true" />
+          </button>
+        </Badge>
+      ))}
+    </div>
+  );
+}

--- a/src/features/exchange-rate-calculator/components/exchange-rate-calculator-page.tsx
+++ b/src/features/exchange-rate-calculator/components/exchange-rate-calculator-page.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useCallback } from "react";
+import { AlertCircle } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useExchangeRateCalculator } from "../lib/use-exchange-rate-calculator";
+import { useFavoritePairs } from "../lib/use-favorite-pairs";
+import { ConverterPanel } from "./converter-panel";
+import { FavoritePairs } from "./favorite-pairs";
+import { RateHistoryChart } from "./rate-history-chart";
+
+export function ExchangeRateCalculatorPage() {
+  const {
+    amount,
+    setAmount,
+    base,
+    targets,
+    primaryTarget,
+    currencies,
+    currenciesError,
+    rates,
+    ratesError,
+    ratesLoading,
+    history,
+    historyError,
+    historyLoading,
+    conversions,
+    setBase,
+    setPrimaryTarget,
+    addTarget,
+    removeTarget,
+    moveTarget,
+    swap,
+    applyPair,
+  } = useExchangeRateCalculator();
+
+  const favorites = useFavoritePairs();
+  const isFavorite = favorites.has(base, primaryTarget);
+
+  const handleToggleFavorite = useCallback(() => {
+    if (base === primaryTarget) return;
+    if (isFavorite) {
+      const target = favorites.pairs.find(
+        (p) => p.from === base && p.to === primaryTarget
+      );
+      if (target) favorites.remove(target.id);
+    } else {
+      favorites.add(base, primaryTarget);
+    }
+  }, [base, primaryTarget, isFavorite, favorites]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Exchange Rate Calculator</h1>
+        <p className="mt-2 text-muted-foreground">
+          ECBが公表する日次の為替レートで通貨を変換します。Frankfurter API を使用しています（平日1日1回更新、週末・祝日は直近営業日のレート）。
+        </p>
+      </div>
+
+      {currenciesError && (
+        <Alert variant="destructive" role="alert">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>通貨一覧の取得に失敗しました</AlertTitle>
+          <AlertDescription>{currenciesError.message}</AlertDescription>
+        </Alert>
+      )}
+
+      {ratesError && (
+        <Alert variant="destructive" role="alert">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>為替レートの取得に失敗しました</AlertTitle>
+          <AlertDescription>{ratesError.message}</AlertDescription>
+        </Alert>
+      )}
+
+      <ConverterPanel
+        amount={amount}
+        onAmountChange={setAmount}
+        base={base}
+        onBaseChange={setBase}
+        primaryTarget={primaryTarget}
+        onPrimaryTargetChange={setPrimaryTarget}
+        targets={targets}
+        onAddTarget={addTarget}
+        onRemoveTarget={removeTarget}
+        onMoveTarget={moveTarget}
+        onSwap={swap}
+        conversions={conversions}
+        ratesDate={rates?.date ?? null}
+        ratesLoading={ratesLoading}
+        currencies={currencies}
+        isFavorite={isFavorite}
+        onToggleFavorite={handleToggleFavorite}
+      />
+
+      <FavoritePairs
+        pairs={favorites.pairs}
+        onApply={applyPair}
+        onRemove={favorites.remove}
+      />
+
+      {historyError ? (
+        <Alert variant="destructive" role="alert">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>レート推移の取得に失敗しました</AlertTitle>
+          <AlertDescription>{historyError.message}</AlertDescription>
+        </Alert>
+      ) : (
+        <RateHistoryChart
+          base={base}
+          target={primaryTarget}
+          history={history}
+          loading={historyLoading}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/features/exchange-rate-calculator/components/favorite-pairs.tsx
+++ b/src/features/exchange-rate-calculator/components/favorite-pairs.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { X } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import type { CurrencyCode, FavoritePair } from "../lib/types";
+
+type Props = {
+  pairs: FavoritePair[];
+  onApply: (from: CurrencyCode, to: CurrencyCode) => void;
+  onRemove: (id: string) => void;
+};
+
+export function FavoritePairs({ pairs, onApply, onRemove }: Props) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>お気に入り通貨ペア</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {pairs.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            よく使う通貨ペアを「お気に入り」ボタンで登録できます。
+          </p>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {pairs.map((pair) => (
+              <Badge
+                key={pair.id}
+                variant="outline"
+                className="gap-1 px-2 py-1 font-mono text-sm"
+              >
+                <button
+                  type="button"
+                  onClick={() => onApply(pair.from, pair.to)}
+                  className="hover:underline"
+                >
+                  {pair.from} → {pair.to}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onRemove(pair.id)}
+                  aria-label={`お気に入り ${pair.from} → ${pair.to} を削除`}
+                  className="ml-1 inline-flex items-center justify-center rounded-sm hover:bg-muted-foreground/20"
+                >
+                  <X className="h-3 w-3" aria-hidden="true" />
+                </button>
+              </Badge>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/exchange-rate-calculator/components/rate-history-chart.tsx
+++ b/src/features/exchange-rate-calculator/components/rate-history-chart.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { CurrencyCode, Timeseries } from "../lib/types";
+
+type Props = {
+  base: CurrencyCode;
+  target: CurrencyCode;
+  history: Timeseries | null;
+  loading: boolean;
+};
+
+function formatLabel(isoDate: string): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
+  if (!match) return isoDate;
+  return `${match[2]}/${match[3]}`;
+}
+
+const CHART_CLASS = "h-[260px] w-full";
+
+export function RateHistoryChart({ base, target, history, loading }: Props) {
+  const config = {
+    rate: {
+      label: `${base} → ${target}`,
+      color: "var(--chart-1)",
+    },
+  } satisfies ChartConfig;
+
+  const data = history
+    ? history.points.map((p) => ({
+        label: formatLabel(p.date),
+        rate: p.rate,
+      }))
+    : [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>過去30日のレート推移（{base} → {target}）</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <Skeleton className="h-[260px] w-full" />
+        ) : data.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            推移データがありません。
+          </p>
+        ) : (
+          <ChartContainer config={config} className={CHART_CLASS}>
+            <LineChart
+              data={data}
+              margin={{ top: 8, right: 12, left: 0, bottom: 0 }}
+            >
+              <CartesianGrid vertical={false} strokeDasharray="3 3" />
+              <XAxis
+                dataKey="label"
+                tickLine={false}
+                axisLine={false}
+                minTickGap={24}
+              />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                width={64}
+                domain={["auto", "auto"]}
+              />
+              <ChartTooltip content={<ChartTooltipContent indicator="line" />} />
+              <Line
+                type="monotone"
+                dataKey="rate"
+                stroke="var(--color-rate)"
+                strokeWidth={2}
+                dot={false}
+              />
+            </LineChart>
+          </ChartContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/exchange-rate-calculator/lib/__tests__/calculator.test.ts
+++ b/src/features/exchange-rate-calculator/lib/__tests__/calculator.test.ts
@@ -1,0 +1,47 @@
+import { convert, formatAmount, formatRate } from "../calculator";
+
+describe("convert", () => {
+  it("multiplies amount by rate", () => {
+    expect(convert(100, 150)).toBe(15000);
+  });
+
+  it("returns 0 when amount is 0", () => {
+    expect(convert(0, 150)).toBe(0);
+  });
+
+  it("handles fractional rate", () => {
+    expect(convert(10, 0.85)).toBeCloseTo(8.5, 6);
+  });
+});
+
+describe("formatAmount", () => {
+  it("formats JPY without fractional part", () => {
+    expect(formatAmount(15000, "JPY")).toMatch(/15,000/);
+  });
+
+  it("formats USD with currency symbol", () => {
+    const result = formatAmount(123.45, "USD");
+    expect(result).toMatch(/\$/);
+    expect(result).toMatch(/123/);
+  });
+
+  it("returns dash for non-finite values", () => {
+    expect(formatAmount(Number.NaN, "USD")).toBe("—");
+    expect(formatAmount(Number.POSITIVE_INFINITY, "USD")).toBe("—");
+  });
+
+  it("falls back gracefully for unknown currency code", () => {
+    const result = formatAmount(100, "XYZ");
+    expect(result).toContain("100");
+  });
+});
+
+describe("formatRate", () => {
+  it("formats a finite rate with grouping separators", () => {
+    expect(formatRate(1234.5678)).toMatch(/1,234/);
+  });
+
+  it("returns dash for non-finite", () => {
+    expect(formatRate(Number.NaN)).toBe("—");
+  });
+});

--- a/src/features/exchange-rate-calculator/lib/__tests__/exchange-rate-client.test.ts
+++ b/src/features/exchange-rate-calculator/lib/__tests__/exchange-rate-client.test.ts
@@ -1,0 +1,129 @@
+import {
+  ExchangeRateError,
+  fetchCurrencies,
+  fetchLatestRates,
+  fetchTimeseries,
+} from "../exchange-rate-client";
+
+describe("fetchCurrencies", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("returns currency map on success", async () => {
+    const payload = { USD: "United States Dollar", JPY: "Japanese Yen" };
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(payload),
+    });
+    global.fetch = fetchMock;
+
+    const result = await fetchCurrencies();
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("mode=currencies"));
+  });
+});
+
+describe("fetchLatestRates", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("returns latest rates on success", async () => {
+    const payload = { base: "USD", date: "2026-04-30", rates: { JPY: 150.1, EUR: 0.92 } };
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(payload),
+    });
+    global.fetch = fetchMock;
+
+    const result = await fetchLatestRates("USD", ["JPY", "EUR"]);
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("mode=latest"));
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("from=USD"));
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("to=JPY%2CEUR"));
+  });
+
+  it("throws ExchangeRateError with errorCode on validation error", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () =>
+        Promise.resolve({
+          error: "from は3文字の通貨コードを指定してください。",
+          errorCode: "VALIDATION_ERROR",
+        }),
+    });
+
+    const error = await fetchLatestRates("X", ["JPY"]).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ExchangeRateError);
+    expect((error as ExchangeRateError).errorCode).toBe("VALIDATION_ERROR");
+    expect((error as ExchangeRateError).message).toContain("from");
+  });
+
+  it("throws fallback error when response body is not JSON", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: () => Promise.reject(new Error("invalid")),
+    });
+
+    await expect(fetchLatestRates("USD", ["JPY"])).rejects.toThrow(
+      "リクエストに失敗しました。（502）"
+    );
+  });
+
+  it("propagates RATE_LIMITED errorCode", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: () =>
+        Promise.resolve({
+          error: "リクエストが多すぎます。",
+          errorCode: "RATE_LIMITED",
+        }),
+    });
+
+    const error = await fetchLatestRates("USD", ["JPY"]).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ExchangeRateError);
+    expect((error as ExchangeRateError).errorCode).toBe("RATE_LIMITED");
+  });
+});
+
+describe("fetchTimeseries", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("returns timeseries on success", async () => {
+    const payload = {
+      base: "USD",
+      target: "JPY",
+      start: "2026-04-01",
+      end: "2026-04-30",
+      points: [
+        { date: "2026-04-01", rate: 150.0 },
+        { date: "2026-04-02", rate: 150.1 },
+      ],
+    };
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(payload),
+    });
+    global.fetch = fetchMock;
+
+    const result = await fetchTimeseries("USD", "JPY", "2026-04-01", "2026-04-30");
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("mode=timeseries"));
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("from=USD"));
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("to=JPY"));
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("start=2026-04-01"));
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("end=2026-04-30"));
+  });
+});

--- a/src/features/exchange-rate-calculator/lib/__tests__/use-favorite-pairs.test.ts
+++ b/src/features/exchange-rate-calculator/lib/__tests__/use-favorite-pairs.test.ts
@@ -1,0 +1,84 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useFavoritePairs } from "../use-favorite-pairs";
+
+const STORAGE_KEY = "exchange-rate-calculator:favorite-pairs";
+
+describe("useFavoritePairs", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("starts empty when localStorage has no entries", async () => {
+    const { result } = renderHook(() => useFavoritePairs());
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+    expect(result.current.pairs).toEqual([]);
+  });
+
+  it("hydrates from localStorage on mount", async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([{ id: "abc", from: "USD", to: "JPY" }])
+    );
+
+    const { result } = renderHook(() => useFavoritePairs());
+    await waitFor(() => expect(result.current.pairs).toHaveLength(1));
+    expect(result.current.pairs[0]).toEqual({ id: "abc", from: "USD", to: "JPY" });
+    expect(result.current.has("USD", "JPY")).toBe(true);
+  });
+
+  it("ignores corrupt JSON in localStorage", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "{not json");
+
+    const { result } = renderHook(() => useFavoritePairs());
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+    expect(result.current.pairs).toEqual([]);
+  });
+
+  it("adds a new pair and persists to localStorage", async () => {
+    const { result } = renderHook(() => useFavoritePairs());
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+
+    act(() => {
+      result.current.add("USD", "JPY");
+    });
+
+    expect(result.current.pairs).toHaveLength(1);
+    expect(result.current.pairs[0]).toMatchObject({ from: "USD", to: "JPY" });
+    expect(result.current.has("USD", "JPY")).toBe(true);
+
+    const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "[]");
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({ from: "USD", to: "JPY" });
+  });
+
+  it("does not add a duplicate pair", async () => {
+    const { result } = renderHook(() => useFavoritePairs());
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+
+    act(() => {
+      result.current.add("USD", "JPY");
+    });
+    act(() => {
+      result.current.add("USD", "JPY");
+    });
+
+    expect(result.current.pairs).toHaveLength(1);
+  });
+
+  it("removes a pair by id", async () => {
+    const { result } = renderHook(() => useFavoritePairs());
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+
+    act(() => {
+      result.current.add("USD", "JPY");
+    });
+    const id = result.current.pairs[0].id;
+
+    act(() => {
+      result.current.remove(id);
+    });
+
+    expect(result.current.pairs).toEqual([]);
+    expect(result.current.has("USD", "JPY")).toBe(false);
+  });
+});

--- a/src/features/exchange-rate-calculator/lib/calculator.ts
+++ b/src/features/exchange-rate-calculator/lib/calculator.ts
@@ -1,0 +1,24 @@
+import type { CurrencyCode } from "./types";
+
+export function convert(amount: number, rate: number): number {
+  return amount * rate;
+}
+
+export function formatAmount(value: number, currency: CurrencyCode): string {
+  if (!Number.isFinite(value)) return "—";
+  try {
+    return new Intl.NumberFormat("ja-JP", {
+      style: "currency",
+      currency,
+      currencyDisplay: "symbol",
+      maximumFractionDigits: 4,
+    }).format(value);
+  } catch {
+    return `${value.toLocaleString("ja-JP", { maximumFractionDigits: 4 })} ${currency}`;
+  }
+}
+
+export function formatRate(rate: number): string {
+  if (!Number.isFinite(rate)) return "—";
+  return rate.toLocaleString("ja-JP", { maximumFractionDigits: 6 });
+}

--- a/src/features/exchange-rate-calculator/lib/exchange-rate-client.ts
+++ b/src/features/exchange-rate-calculator/lib/exchange-rate-client.ts
@@ -1,0 +1,61 @@
+import type {
+  ApiErrorCode,
+  CurrencyCode,
+  CurrencyMap,
+  LatestRates,
+  Timeseries,
+} from "./types";
+
+export class ExchangeRateError extends Error {
+  readonly errorCode: ApiErrorCode | undefined;
+
+  constructor(message: string, errorCode?: ApiErrorCode) {
+    super(message);
+    this.name = "ExchangeRateError";
+    this.errorCode = errorCode;
+  }
+}
+
+async function request<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    const message =
+      body?.error ?? `リクエストに失敗しました。（${res.status}）`;
+    throw new ExchangeRateError(message, body?.errorCode);
+  }
+  return res.json() as Promise<T>;
+}
+
+export function fetchCurrencies(): Promise<CurrencyMap> {
+  const params = new URLSearchParams({ mode: "currencies" });
+  return request<CurrencyMap>(`/api/exchange-rate?${params.toString()}`);
+}
+
+export function fetchLatestRates(
+  base: CurrencyCode,
+  targets: CurrencyCode[]
+): Promise<LatestRates> {
+  const params = new URLSearchParams({
+    mode: "latest",
+    from: base,
+    to: targets.join(","),
+  });
+  return request<LatestRates>(`/api/exchange-rate?${params.toString()}`);
+}
+
+export function fetchTimeseries(
+  base: CurrencyCode,
+  target: CurrencyCode,
+  start: string,
+  end: string
+): Promise<Timeseries> {
+  const params = new URLSearchParams({
+    mode: "timeseries",
+    from: base,
+    to: target,
+    start,
+    end,
+  });
+  return request<Timeseries>(`/api/exchange-rate?${params.toString()}`);
+}

--- a/src/features/exchange-rate-calculator/lib/types.ts
+++ b/src/features/exchange-rate-calculator/lib/types.ts
@@ -1,0 +1,34 @@
+export type ApiErrorCode =
+  | "VALIDATION_ERROR"
+  | "RATE_LIMITED"
+  | "UPSTREAM_ERROR"
+  | "SERVER_ERROR";
+
+export type CurrencyCode = string;
+
+export type CurrencyMap = Record<CurrencyCode, string>;
+
+export type LatestRates = {
+  base: CurrencyCode;
+  date: string;
+  rates: Record<CurrencyCode, number>;
+};
+
+export type TimeseriesPoint = {
+  date: string;
+  rate: number;
+};
+
+export type Timeseries = {
+  base: CurrencyCode;
+  target: CurrencyCode;
+  start: string;
+  end: string;
+  points: TimeseriesPoint[];
+};
+
+export type FavoritePair = {
+  id: string;
+  from: CurrencyCode;
+  to: CurrencyCode;
+};

--- a/src/features/exchange-rate-calculator/lib/use-exchange-rate-calculator.ts
+++ b/src/features/exchange-rate-calculator/lib/use-exchange-rate-calculator.ts
@@ -1,0 +1,269 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ExchangeRateError,
+  fetchCurrencies,
+  fetchLatestRates,
+  fetchTimeseries,
+} from "./exchange-rate-client";
+import type {
+  ApiErrorCode,
+  CurrencyCode,
+  CurrencyMap,
+  LatestRates,
+  Timeseries,
+} from "./types";
+
+const DEFAULT_BASE: CurrencyCode = "USD";
+const DEFAULT_TARGETS: CurrencyCode[] = ["JPY", "EUR", "GBP"];
+const DEFAULT_PRIMARY: CurrencyCode = "JPY";
+const DEFAULT_AMOUNT = "100";
+const HISTORY_DAYS = 30;
+
+type ErrorState = {
+  message: string;
+  errorCode?: ApiErrorCode;
+};
+
+function toIsoDate(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function rangeKey(base: CurrencyCode, targets: CurrencyCode[]): string {
+  return `${base}|${[...targets].sort().join(",")}`;
+}
+
+function timeseriesKey(base: CurrencyCode, target: CurrencyCode): string {
+  return `${base}->${target}`;
+}
+
+function toErrorState(e: unknown): ErrorState {
+  if (e instanceof ExchangeRateError) {
+    return { message: e.message, errorCode: e.errorCode };
+  }
+  return {
+    message: e instanceof Error ? e.message : "為替レートの取得に失敗しました。",
+  };
+}
+
+export function useExchangeRateCalculator() {
+  const [amount, setAmount] = useState<string>(DEFAULT_AMOUNT);
+  const [base, setBase] = useState<CurrencyCode>(DEFAULT_BASE);
+  const [targets, setTargets] = useState<CurrencyCode[]>(DEFAULT_TARGETS);
+  const [primaryTarget, setPrimaryTarget] = useState<CurrencyCode>(DEFAULT_PRIMARY);
+
+  const [currencies, setCurrencies] = useState<CurrencyMap | null>(null);
+  const [currenciesError, setCurrenciesError] = useState<ErrorState | null>(null);
+
+  const [ratesResult, setRatesResult] = useState<{ data: LatestRates; key: string } | null>(null);
+  const [ratesError, setRatesError] = useState<{ error: ErrorState; key: string } | null>(null);
+
+  const [historyResult, setHistoryResult] = useState<{ data: Timeseries; key: string } | null>(null);
+  const [historyError, setHistoryError] = useState<{ error: ErrorState; key: string } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchCurrencies()
+      .then((data) => {
+        if (cancelled) return;
+        setCurrencies(data);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setCurrenciesError(toErrorState(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const ratesKey = rangeKey(base, targets);
+  useEffect(() => {
+    if (targets.length === 0) return;
+    let cancelled = false;
+    fetchLatestRates(base, targets)
+      .then((data) => {
+        if (cancelled) return;
+        setRatesResult({ data, key: ratesKey });
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setRatesError({ error: toErrorState(e), key: ratesKey });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [base, targets, ratesKey]);
+
+  const historyKey = timeseriesKey(base, primaryTarget);
+  useEffect(() => {
+    if (base === primaryTarget) return;
+    let cancelled = false;
+    const today = new Date();
+    const startDate = new Date(today.getTime() - HISTORY_DAYS * 86_400_000);
+    const start = toIsoDate(startDate);
+    const end = toIsoDate(today);
+    fetchTimeseries(base, primaryTarget, start, end)
+      .then((data) => {
+        if (cancelled) return;
+        setHistoryResult({ data, key: historyKey });
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setHistoryError({ error: toErrorState(e), key: historyKey });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [base, primaryTarget, historyKey]);
+
+  const rates =
+    targets.length > 0 && ratesResult && ratesResult.key === ratesKey
+      ? ratesResult.data
+      : null;
+  const ratesActiveError =
+    ratesError && ratesError.key === ratesKey ? ratesError.error : null;
+  const ratesLoading = targets.length > 0 && rates === null && ratesActiveError === null;
+
+  const history =
+    base !== primaryTarget && historyResult && historyResult.key === historyKey
+      ? historyResult.data
+      : null;
+  const historyActiveError =
+    historyError && historyError.key === historyKey ? historyError.error : null;
+  const historyLoading =
+    base !== primaryTarget && history === null && historyActiveError === null;
+
+  const parsedAmount = useMemo(() => {
+    const n = parseFloat(amount);
+    return Number.isFinite(n) ? n : null;
+  }, [amount]);
+
+  const conversions = useMemo(() => {
+    if (!rates) return [];
+    return targets.map((currency) => {
+      const rate = rates.rates[currency];
+      const converted =
+        parsedAmount !== null && Number.isFinite(rate)
+          ? parsedAmount * rate
+          : null;
+      return { currency, rate, converted };
+    });
+  }, [rates, targets, parsedAmount]);
+
+  const addTarget = useCallback(
+    (currency: CurrencyCode) => {
+      setTargets((prev) => {
+        if (prev.includes(currency)) return prev;
+        if (currency === base) return prev;
+        return [...prev, currency];
+      });
+    },
+    [base]
+  );
+
+  const removeTarget = useCallback(
+    (currency: CurrencyCode) => {
+      setTargets((prev) => prev.filter((c) => c !== currency));
+      setPrimaryTarget((prev) => {
+        if (prev !== currency) return prev;
+        const next = targets.find((c) => c !== currency);
+        return next ?? prev;
+      });
+    },
+    [targets]
+  );
+
+  const moveTarget = useCallback(
+    (currency: CurrencyCode, direction: "up" | "down") => {
+      setTargets((prev) => {
+        const index = prev.indexOf(currency);
+        if (index < 0) return prev;
+        const swapWith = direction === "up" ? index - 1 : index + 1;
+        if (swapWith < 0 || swapWith >= prev.length) return prev;
+        const next = [...prev];
+        [next[index], next[swapWith]] = [next[swapWith], next[index]];
+        return next;
+      });
+    },
+    []
+  );
+
+  const handleSetBase = useCallback(
+    (currency: CurrencyCode) => {
+      if (currency === base) return;
+      setBase(currency);
+      setTargets((prev) => prev.filter((c) => c !== currency));
+      setPrimaryTarget((prev) => {
+        if (prev === currency) {
+          const next = targets.find((c) => c !== currency && c !== base) ?? base;
+          return next;
+        }
+        return prev;
+      });
+    },
+    [base, targets]
+  );
+
+  const handleSetPrimaryTarget = useCallback(
+    (currency: CurrencyCode) => {
+      if (currency === base) return;
+      setPrimaryTarget(currency);
+      setTargets((prev) => (prev.includes(currency) ? prev : [...prev, currency]));
+    },
+    [base]
+  );
+
+  const swap = useCallback(() => {
+    if (base === primaryTarget) return;
+    const nextBase = primaryTarget;
+    const nextPrimary = base;
+    setBase(nextBase);
+    setPrimaryTarget(nextPrimary);
+    setTargets((prev) => {
+      const filtered = prev.filter((c) => c !== nextBase);
+      return filtered.includes(nextPrimary) ? filtered : [...filtered, nextPrimary];
+    });
+  }, [base, primaryTarget]);
+
+  const applyPair = useCallback(
+    (from: CurrencyCode, to: CurrencyCode) => {
+      if (from === to) return;
+      setBase(from);
+      setPrimaryTarget(to);
+      setTargets((prev) => {
+        const filtered = prev.filter((c) => c !== from);
+        return filtered.includes(to) ? filtered : [...filtered, to];
+      });
+    },
+    []
+  );
+
+  return {
+    amount,
+    setAmount,
+    base,
+    targets,
+    primaryTarget,
+    currencies,
+    currenciesError,
+    rates,
+    ratesError: ratesActiveError,
+    ratesLoading,
+    history,
+    historyError: historyActiveError,
+    historyLoading,
+    conversions,
+    setBase: handleSetBase,
+    setPrimaryTarget: handleSetPrimaryTarget,
+    addTarget,
+    removeTarget,
+    moveTarget,
+    swap,
+    applyPair,
+  };
+}

--- a/src/features/exchange-rate-calculator/lib/use-exchange-rate-calculator.ts
+++ b/src/features/exchange-rate-calculator/lib/use-exchange-rate-calculator.ts
@@ -89,6 +89,7 @@ export function useExchangeRateCalculator() {
       .then((data) => {
         if (cancelled) return;
         setRatesResult({ data, key: ratesKey });
+        setRatesError(null);
       })
       .catch((e: unknown) => {
         if (cancelled) return;
@@ -111,6 +112,7 @@ export function useExchangeRateCalculator() {
       .then((data) => {
         if (cancelled) return;
         setHistoryResult({ data, key: historyKey });
+        setHistoryError(null);
       })
       .catch((e: unknown) => {
         if (cancelled) return;

--- a/src/features/exchange-rate-calculator/lib/use-favorite-pairs.ts
+++ b/src/features/exchange-rate-calculator/lib/use-favorite-pairs.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { CurrencyCode, FavoritePair } from "./types";
+
+const STORAGE_KEY = "exchange-rate-calculator:favorite-pairs";
+
+function isFavoritePair(value: unknown): value is FavoritePair {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === "string" &&
+    typeof v.from === "string" &&
+    typeof v.to === "string"
+  );
+}
+
+function loadFromStorage(): FavoritePair[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isFavoritePair);
+  } catch {
+    return [];
+  }
+}
+
+export function useFavoritePairs() {
+  const [pairs, setPairs] = useState<FavoritePair[]>([]);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    // localStorage はクライアント側のみで参照できる外部システムのため、
+    // マウント後の同期は副作用として扱う必要がある。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setPairs(loadFromStorage());
+    setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(pairs));
+    } catch {
+      // ignore quota / serialization errors
+    }
+  }, [pairs, hydrated]);
+
+  const has = useCallback(
+    (from: CurrencyCode, to: CurrencyCode) =>
+      pairs.some((p) => p.from === from && p.to === to),
+    [pairs]
+  );
+
+  const add = useCallback((from: CurrencyCode, to: CurrencyCode) => {
+    setPairs((prev) => {
+      if (prev.some((p) => p.from === from && p.to === to)) return prev;
+      return [...prev, { id: crypto.randomUUID(), from, to }];
+    });
+  }, []);
+
+  const remove = useCallback((id: string) => {
+    setPairs((prev) => prev.filter((p) => p.id !== id));
+  }, []);
+
+  return { pairs, hydrated, has, add, remove };
+}


### PR DESCRIPTION
## Summary
- Frankfurter API（ECB公表の日次為替レート）で通貨換算する新ツール `/tools/exchange-rate-calculator` を追加
- 複数通貨への同時変換、↑↓ボタンによる並び替え、Swap、お気に入り通貨ペア（localStorage 永続化）を実装
- 過去30日のレート推移グラフを recharts で表示
- API ルート `/api/exchange-rate`（`mode=currencies/latest/timeseries`）に既存の `createRateLimit` / `getClientIp` を流用
- ロジック層の Jest テスト3本（calculator / exchange-rate-client / use-favorite-pairs）を追加

Closes #35

## Test plan
- [ ] `npm run lint` がエラー0で通る
- [ ] `npm run test` で全 530 テストが pass
- [ ] `npm run build` が成功する
- [ ] `/tools/exchange-rate-calculator` を開き、初期表示で USD 100 が JPY/EUR/GBP に換算される
- [ ] 金額・base 通貨・target 通貨の変更で結果が即時更新される
- [ ] 「変換先を追加」ドロップダウンがトリガー直下に表示される（左下に出ない）
- [ ] 各行の ↑↓ ボタンで並び替えができ、最上行は ↑ 無効、最下行は ↓ 無効になる
- [ ] Swap で base ↔ 主要な変換先が入れ替わる
- [ ] お気に入りボタンで現在のペアを登録でき、ページリロード後も保持される
- [ ] お気に入り Badge クリックで該当ペアが復元される
- [ ] 過去30日のレート推移グラフが表示され、主要な変換先の切り替えで再描画される
- [ ] 不正な通貨コードで API が 400 を返し、赤い Alert が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)