### PR TITLE
chore: Node.js を 20 から 22 LTS に更新（20 EOL 対応）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  NODE_VERSION: 20
+  NODE_VERSION: 22
 
 jobs:
   eol-check:

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/diff": "^7.0.2",
         "@types/jest": "^30.0.0",
-        "@types/node": "^20",
+        "@types/node": "^22",
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -5390,9 +5390,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
-      "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/diff": "^7.0.2",
     "@types/jest": "^30.0.0",
-    "@types/node": "^20",
+    "@types/node": "^22",
     "@types/qrcode": "^1.5.6",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml` の `NODE_VERSION` を `20` → `22` に更新（Node 20 が 2026-04-30 で EOL となり、`eol-check` ジョブが全 PR で fail する状態を解消）
- `package.json` の `@types/node` を `^20` → `^22` に更新し、ランタイムと型定義のメジャーを揃える
- `package-lock.json` は `npm install` により自動更新

Closes #181

## Test plan
- [ ] CI の `eol-check` ジョブが pass する
- [ ] CI の `lint` / `test` / `build` ジョブがすべて pass する
- [ ] マージ後、PR #180 を rebase / re-run し CI が通ることを確認

## Notes
- ローカル検証済み: `npm run lint`（0 errors）/ `npm run test`（530/530 passed）/ `npm run build`（成功）/ `npx tsc --noEmit`（型エラーなし）
- ソースコード側で Node の組み込みモジュール（`fs`, `crypto` 等）や `node:` 名前空間は未使用のため、Node 22 への更新による実装上の影響はなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)