### PR TITLE
chore: split-bill-calculator のページに metadata を追加

### DIFF
--- a/src/app/tools/split-bill-calculator/page.tsx
+++ b/src/app/tools/split-bill-calculator/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from "next";
 import { SplitBillCalculatorPage } from "@/features/split-bill-calculator/components/split-bill-calculator-page";
+
+export const metadata: Metadata = {
+  title: "Split Bill Calculator - Personal Tools",
+  description: "割り勘計算、端数処理、傾斜配分、税・サービス料の別計算",
+};
 
 export default function Page() {
   return <SplitBillCalculatorPage />;


### PR DESCRIPTION
## Summary
- `src/app/tools/split-bill-calculator/page.tsx` に `import type { Metadata } from \"next\"` と `export const metadata: Metadata` を追加
- title は `Split Bill Calculator - Personal Tools`、description は `src/app/page.tsx` のカード説明文と一致させ、他ツールページと規約を揃えた

Closes #182

## Test plan
- [x] `npm run lint` が pass する
- [x] `npm run build` が pass する
- [x] `npm run test` が pass する（530 tests passed）
- [ ] ブラウザで `/tools/split-bill-calculator` を開き、タブタイトルが `Split Bill Calculator - Personal Tools` になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)