### PR TITLE
feat: GitHub Repo Analyzer (MVP) を追加

### DIFF
--- a/src/app/api/github/route.ts
+++ b/src/app/api/github/route.ts
@@ -1,0 +1,250 @@
+import { NextResponse } from "next/server";
+import { createRateLimit } from "@/lib/rate-limit";
+import { getClientIp, rateLimitResponse } from "@/lib/api-helpers";
+import type {
+  LanguageBreakdown,
+  RepoStats,
+  RepoSummary,
+  SortKey,
+} from "@/features/github-repo-analyzer/lib/types";
+
+const GITHUB_API_BASE = "https://api.github.com";
+const USER_AGENT = "personal-tools";
+const USERNAME_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$/;
+const REPO_NAME_PATTERN = /^[A-Za-z0-9._-]{1,100}$/;
+const REPOS_PER_PAGE = 100;
+const MAX_REPOS = 100;
+
+const rateLimit = createRateLimit({ limit: 30, windowMs: 60_000 });
+
+export async function GET(request: Request) {
+  const ip = getClientIp(request);
+  if (ip !== "unknown") {
+    const result = rateLimit.check(ip);
+    if (!result.allowed) {
+      return rateLimitResponse(result.retryAfterMs);
+    }
+  }
+
+  const { searchParams } = new URL(request.url);
+  const mode = searchParams.get("mode");
+
+  if (mode === "repos") {
+    return handleRepos(searchParams);
+  }
+  if (mode === "repo-stats") {
+    return handleRepoStats(searchParams);
+  }
+  return validationError(
+    "mode は repos / repo-stats のいずれかを指定してください。"
+  );
+}
+
+async function handleRepos(params: URLSearchParams): Promise<Response> {
+  const username = params.get("username") ?? "";
+  const sortRaw = params.get("sort") ?? "updated";
+
+  if (!USERNAME_PATTERN.test(username)) {
+    return validationError(
+      "username は1〜39文字の英数字とハイフンで指定してください。"
+    );
+  }
+  const sort: SortKey = sortRaw === "stars" ? "stars" : "updated";
+
+  const url = new URL(`${GITHUB_API_BASE}/users/${username}/repos`);
+  url.searchParams.set("per_page", String(REPOS_PER_PAGE));
+  url.searchParams.set("type", "owner");
+  url.searchParams.set("sort", "updated");
+
+  const upstream = await fetchUpstream(
+    url,
+    "リポジトリ一覧の取得に失敗しました。"
+  );
+  if (!upstream.ok) return upstream.errorResponse;
+
+  const raw = (await upstream.response.json()) as GithubRepoResponse[];
+  let summaries: RepoSummary[] = raw.map(toRepoSummary);
+  if (sort === "stars") {
+    summaries = [...summaries].sort(
+      (a, b) => b.stargazersCount - a.stargazersCount
+    );
+  }
+  if (summaries.length > MAX_REPOS) {
+    summaries = summaries.slice(0, MAX_REPOS);
+  }
+  return NextResponse.json({ repos: summaries });
+}
+
+async function handleRepoStats(params: URLSearchParams): Promise<Response> {
+  const owner = params.get("owner") ?? "";
+  const repo = params.get("repo") ?? "";
+
+  if (!USERNAME_PATTERN.test(owner)) {
+    return validationError(
+      "owner は1〜39文字の英数字とハイフンで指定してください。"
+    );
+  }
+  if (!REPO_NAME_PATTERN.test(repo)) {
+    return validationError(
+      "repo は1〜100文字の英数字・ドット・アンダースコア・ハイフンで指定してください。"
+    );
+  }
+
+  const languagesUrl = new URL(
+    `${GITHUB_API_BASE}/repos/${owner}/${repo}/languages`
+  );
+  const issueSearchUrl = new URL(`${GITHUB_API_BASE}/search/issues`);
+  issueSearchUrl.searchParams.set(
+    "q",
+    `repo:${owner}/${repo} state:open is:issue`
+  );
+  issueSearchUrl.searchParams.set("per_page", "1");
+  const prSearchUrl = new URL(`${GITHUB_API_BASE}/search/issues`);
+  prSearchUrl.searchParams.set("q", `repo:${owner}/${repo} state:open is:pr`);
+  prSearchUrl.searchParams.set("per_page", "1");
+
+  const [languagesResult, issuesResult, prsResult] = await Promise.all([
+    fetchUpstream(languagesUrl, "言語比率の取得に失敗しました。"),
+    fetchUpstream(issueSearchUrl, "Issue 数の取得に失敗しました。"),
+    fetchUpstream(prSearchUrl, "Pull Request 数の取得に失敗しました。"),
+  ]);
+
+  if (!languagesResult.ok) return languagesResult.errorResponse;
+  if (!issuesResult.ok) return issuesResult.errorResponse;
+  if (!prsResult.ok) return prsResult.errorResponse;
+
+  const languages = (await languagesResult.response.json()) as LanguageBreakdown;
+  const issuesPayload =
+    (await issuesResult.response.json()) as GithubSearchResponse;
+  const prsPayload = (await prsResult.response.json()) as GithubSearchResponse;
+
+  const stats: RepoStats = {
+    languages,
+    openIssueCount: issuesPayload.total_count ?? 0,
+    openPullRequestCount: prsPayload.total_count ?? 0,
+  };
+  return NextResponse.json(stats);
+}
+
+type UpstreamResult =
+  | { ok: true; response: Response }
+  | { ok: false; errorResponse: Response };
+
+async function fetchUpstream(
+  url: URL,
+  failureMessage: string
+): Promise<UpstreamResult> {
+  let upstream: Response;
+  try {
+    upstream = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": USER_AGENT,
+      },
+    });
+  } catch {
+    return {
+      ok: false,
+      errorResponse: NextResponse.json(
+        {
+          error: "GitHub に接続できませんでした。",
+          errorCode: "UPSTREAM_ERROR",
+        },
+        { status: 502 }
+      ),
+    };
+  }
+
+  if (!upstream.ok) {
+    if (upstream.status === 404) {
+      return {
+        ok: false,
+        errorResponse: NextResponse.json(
+          {
+            error: "指定されたリソースが見つかりませんでした。",
+            errorCode: "NOT_FOUND",
+          },
+          { status: 404 }
+        ),
+      };
+    }
+    if (
+      upstream.status === 403 &&
+      upstream.headers.get("X-RateLimit-Remaining") === "0"
+    ) {
+      return {
+        ok: false,
+        errorResponse: NextResponse.json(
+          {
+            error:
+              "GitHub API のレート制限に達しました。しばらく経ってから再度お試しください。",
+            errorCode: "RATE_LIMITED",
+          },
+          { status: 429 }
+        ),
+      };
+    }
+    if (upstream.status === 422) {
+      return {
+        ok: false,
+        errorResponse: NextResponse.json(
+          { error: failureMessage, errorCode: "VALIDATION_ERROR" },
+          { status: 400 }
+        ),
+      };
+    }
+    return {
+      ok: false,
+      errorResponse: NextResponse.json(
+        { error: failureMessage, errorCode: "UPSTREAM_ERROR" },
+        { status: 502 }
+      ),
+    };
+  }
+
+  return { ok: true, response: upstream };
+}
+
+function validationError(message: string): Response {
+  return NextResponse.json(
+    { error: message, errorCode: "VALIDATION_ERROR" },
+    { status: 400 }
+  );
+}
+
+function toRepoSummary(raw: GithubRepoResponse): RepoSummary {
+  return {
+    id: raw.id,
+    name: raw.name,
+    fullName: raw.full_name,
+    description: raw.description,
+    htmlUrl: raw.html_url,
+    stargazersCount: raw.stargazers_count ?? 0,
+    forksCount: raw.forks_count ?? 0,
+    openIssuesCount: raw.open_issues_count ?? 0,
+    language: raw.language,
+    updatedAt: raw.updated_at,
+    isFork: raw.fork ?? false,
+    isArchived: raw.archived ?? false,
+  };
+}
+
+type GithubRepoResponse = {
+  id: number;
+  name: string;
+  full_name: string;
+  description: string | null;
+  html_url: string;
+  stargazers_count?: number;
+  forks_count?: number;
+  open_issues_count?: number;
+  language: string | null;
+  updated_at: string;
+  fork?: boolean;
+  archived?: boolean;
+};
+
+type GithubSearchResponse = {
+  total_count?: number;
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, ArrowLeftRight, Braces, Calculator, Clock, Cloud, Coins, FileText, Fingerprint, FileDiff, Languages, Palette, Package, QrCode, Regex, Timer, Type, type LucideIcon } from "lucide-react";
+import { ArrowRight, ArrowLeftRight, Braces, Calculator, Clock, Cloud, Coins, FileText, Fingerprint, FileDiff, Github, Languages, Palette, Package, QrCode, Regex, Timer, Type, type LucideIcon } from "lucide-react";
 import {
   Card,
   CardHeader,
@@ -137,6 +137,13 @@ const tools: Tool[] = [
     description: "ECB公表の日次為替レートで通貨変換、お気に入り通貨ペア・30日推移グラフ",
     href: "/tools/exchange-rate-calculator",
     icon: Coins,
+    category: "external-api",
+  },
+  {
+    name: "GitHub Repo Analyzer",
+    description: "GitHubユーザーの公開リポジトリ一覧と統計を可視化",
+    href: "/tools/github-repo-analyzer",
+    icon: Github,
     category: "external-api",
   },
 ];

--- a/src/app/tools/github-repo-analyzer/page.tsx
+++ b/src/app/tools/github-repo-analyzer/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import { GithubRepoAnalyzerPage } from "@/features/github-repo-analyzer/components/github-repo-analyzer-page";
+
+export const metadata: Metadata = {
+  title: "GitHub Repo Analyzer - Personal Tools",
+  description: "GitHubユーザーの公開リポジトリ一覧と統計を可視化",
+};
+
+export default function Page() {
+  return <GithubRepoAnalyzerPage />;
+}

--- a/src/features/github-repo-analyzer/components/github-repo-analyzer-page.tsx
+++ b/src/features/github-repo-analyzer/components/github-repo-analyzer-page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { AlertCircle } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useGithubRepos } from "../lib/use-github-repos";
+import type { RepoSummary, SortKey } from "../lib/types";
+import { RepoDetailPanel } from "./repo-detail-panel";
+import { RepoList } from "./repo-list";
+import { UsernameSearchForm } from "./username-search-form";
+
+export function GithubRepoAnalyzerPage() {
+  const [username, setUsername] = useState("");
+  const [sort, setSort] = useState<SortKey>("updated");
+  const [selectedRepo, setSelectedRepo] = useState<RepoSummary | null>(null);
+
+  const { repos, error, loading } = useGithubRepos(username, sort);
+
+  const handleSubmit = (next: string) => {
+    setUsername(next);
+    setSelectedRepo(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">
+          GitHub Repo Analyzer
+        </h1>
+        <p className="mt-2 text-muted-foreground">
+          GitHub の公開リポジトリ情報を取得して可視化します。ユーザー名を入力するとそのユーザーの公開リポジトリ一覧と統計が表示されます（未認証API使用、レート制限60req/h）。
+        </p>
+      </div>
+
+      <UsernameSearchForm onSubmit={handleSubmit} />
+
+      {error && (
+        <Alert variant="destructive" role="alert">
+          <AlertCircle className="size-4" />
+          <AlertTitle>リポジトリの取得に失敗しました</AlertTitle>
+          <AlertDescription>{error.message}</AlertDescription>
+        </Alert>
+      )}
+
+      {username && !error && (
+        <div className="grid gap-6 lg:grid-cols-[1fr_1.2fr]">
+          <RepoList
+            repos={repos}
+            loading={loading}
+            selectedRepoId={selectedRepo?.id ?? null}
+            onSelect={setSelectedRepo}
+            sort={sort}
+            onSortChange={setSort}
+          />
+          <div>
+            {selectedRepo ? (
+              <RepoDetailPanel repo={selectedRepo} />
+            ) : (
+              <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+                リポジトリを選択すると詳細が表示されます。
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/github-repo-analyzer/components/language-breakdown.tsx
+++ b/src/features/github-repo-analyzer/components/language-breakdown.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { computeLanguagePercentages } from "../lib/format";
+import type { LanguageBreakdown as LanguageBreakdownData } from "../lib/types";
+
+type Props = {
+  languages: LanguageBreakdownData;
+};
+
+const COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+];
+
+export function LanguageBreakdown({ languages }: Props) {
+  const entries = computeLanguagePercentages(languages);
+  if (entries.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        言語情報はありません。
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div
+        className="flex h-2 w-full overflow-hidden rounded-full bg-muted"
+        role="img"
+        aria-label="言語比率"
+      >
+        {entries.map((entry, index) => (
+          <span
+            key={entry.language}
+            className="h-full"
+            style={{
+              width: `${entry.percentage}%`,
+              backgroundColor: COLORS[index % COLORS.length],
+            }}
+          />
+        ))}
+      </div>
+      <ul className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm sm:grid-cols-3">
+        {entries.map((entry, index) => (
+          <li key={entry.language} className="flex items-center gap-2">
+            <span
+              className="size-2 shrink-0 rounded-full"
+              style={{ backgroundColor: COLORS[index % COLORS.length] }}
+              aria-hidden="true"
+            />
+            <span className="truncate">{entry.language}</span>
+            <span className="text-muted-foreground">
+              {entry.percentage.toFixed(1)}%
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/github-repo-analyzer/components/repo-card.tsx
+++ b/src/features/github-repo-analyzer/components/repo-card.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { GitFork, Star } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { formatCount, formatRelativeDate } from "../lib/format";
+import type { RepoSummary } from "../lib/types";
+
+type Props = {
+  repo: RepoSummary;
+  selected: boolean;
+  onSelect: (repo: RepoSummary) => void;
+};
+
+export function RepoCard({ repo, selected, onSelect }: Props) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(repo)}
+      aria-pressed={selected}
+      className={cn(
+        "w-full rounded-lg border bg-card p-4 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        selected && "border-primary ring-2 ring-primary"
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate font-semibold">{repo.name}</h3>
+          {repo.description && (
+            <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+              {repo.description}
+            </p>
+          )}
+        </div>
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          {repo.isArchived && <Badge variant="secondary">Archived</Badge>}
+          {repo.isFork && <Badge variant="outline">Fork</Badge>}
+        </div>
+      </div>
+      <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
+        {repo.language && <span>{repo.language}</span>}
+        <span className="inline-flex items-center gap-1">
+          <Star className="size-3.5" aria-hidden="true" />
+          {formatCount(repo.stargazersCount)}
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <GitFork className="size-3.5" aria-hidden="true" />
+          {formatCount(repo.forksCount)}
+        </span>
+        <span>更新 {formatRelativeDate(repo.updatedAt)}</span>
+      </div>
+    </button>
+  );
+}

--- a/src/features/github-repo-analyzer/components/repo-detail-panel.tsx
+++ b/src/features/github-repo-analyzer/components/repo-detail-panel.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { AlertCircle, CircleDot, ExternalLink, GitPullRequest } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { formatCount } from "../lib/format";
+import { useRepoStats } from "../lib/use-repo-stats";
+import { LanguageBreakdown } from "./language-breakdown";
+import type { RepoSummary } from "../lib/types";
+
+type Props = {
+  repo: RepoSummary;
+};
+
+export function RepoDetailPanel({ repo }: Props) {
+  const [owner, name] = repo.fullName.split("/");
+  const { stats, error, loading } = useRepoStats(owner, name);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between gap-2">
+          <span className="truncate">{repo.fullName}</span>
+          <a
+            href={repo.htmlUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center gap-1 text-sm font-normal text-primary hover:underline"
+          >
+            GitHub
+            <ExternalLink className="size-3.5" aria-hidden="true" />
+          </a>
+        </CardTitle>
+        {repo.description && (
+          <CardDescription>{repo.description}</CardDescription>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Stat label="Stars" value={formatCount(repo.stargazersCount)} />
+          <Stat label="Forks" value={formatCount(repo.forksCount)} />
+          <Stat
+            label="Open Issues"
+            value={
+              loading
+                ? null
+                : stats
+                  ? formatCount(stats.openIssueCount)
+                  : "—"
+            }
+            icon={<CircleDot className="size-3.5" aria-hidden="true" />}
+          />
+          <Stat
+            label="Open PRs"
+            value={
+              loading
+                ? null
+                : stats
+                  ? formatCount(stats.openPullRequestCount)
+                  : "—"
+            }
+            icon={<GitPullRequest className="size-3.5" aria-hidden="true" />}
+          />
+        </div>
+
+        <div>
+          <h3 className="mb-2 text-sm font-semibold">言語比率</h3>
+          {loading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-2 w-full" />
+              <Skeleton className="h-4 w-3/4" />
+            </div>
+          ) : error ? (
+            <Alert variant="destructive" role="alert">
+              <AlertCircle className="size-4" />
+              <AlertTitle>統計情報の取得に失敗しました</AlertTitle>
+              <AlertDescription>{error.message}</AlertDescription>
+            </Alert>
+          ) : stats ? (
+            <LanguageBreakdown languages={stats.languages} />
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  icon,
+}: {
+  label: string;
+  value: string | null;
+  icon?: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-md border bg-muted/30 p-3">
+      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+        {icon}
+        {label}
+      </div>
+      {value === null ? (
+        <Skeleton className="mt-1 h-6 w-12" />
+      ) : (
+        <div className="mt-1 text-xl font-semibold">{value}</div>
+      )}
+    </div>
+  );
+}

--- a/src/features/github-repo-analyzer/components/repo-list.tsx
+++ b/src/features/github-repo-analyzer/components/repo-list.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import { RepoCard } from "./repo-card";
+import type { RepoSummary, SortKey } from "../lib/types";
+
+type Props = {
+  repos: RepoSummary[] | null;
+  loading: boolean;
+  selectedRepoId: number | null;
+  onSelect: (repo: RepoSummary) => void;
+  sort: SortKey;
+  onSortChange: (sort: SortKey) => void;
+};
+
+export function RepoList({
+  repos,
+  loading,
+  selectedRepoId,
+  onSelect,
+  sort,
+  onSortChange,
+}: Props) {
+  const sortedRepos = repos
+    ? [...repos].sort((a, b) => {
+        if (sort === "stars") return b.stargazersCount - a.stargazersCount;
+        return Date.parse(b.updatedAt) - Date.parse(a.updatedAt);
+      })
+    : null;
+
+  return (
+    <section className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-lg font-semibold">
+          リポジトリ
+          {sortedRepos && (
+            <span className="ml-2 text-sm font-normal text-muted-foreground">
+              {sortedRepos.length}件
+            </span>
+          )}
+        </h2>
+        <div
+          className="inline-flex rounded-md border bg-background p-0.5"
+          role="radiogroup"
+          aria-label="並び替え"
+        >
+          <SortToggle
+            label="更新日"
+            active={sort === "updated"}
+            onClick={() => onSortChange("updated")}
+          />
+          <SortToggle
+            label="スター数"
+            active={sort === "stars"}
+            onClick={() => onSortChange("stars")}
+          />
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      ) : sortedRepos && sortedRepos.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          公開リポジトリが見つかりませんでした。
+        </p>
+      ) : sortedRepos ? (
+        <div className="space-y-3">
+          {sortedRepos.map((repo) => (
+            <RepoCard
+              key={repo.id}
+              repo={repo}
+              selected={repo.id === selectedRepoId}
+              onSelect={onSelect}
+            />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function SortToggle({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      role="radio"
+      aria-checked={active}
+      className={
+        active
+          ? "rounded-sm bg-primary px-3 py-1 text-sm text-primary-foreground"
+          : "rounded-sm px-3 py-1 text-sm text-muted-foreground hover:text-foreground"
+      }
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/features/github-repo-analyzer/components/username-search-form.tsx
+++ b/src/features/github-repo-analyzer/components/username-search-form.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type Props = {
+  onSubmit: (username: string) => void;
+  initialValue?: string;
+};
+
+export function UsernameSearchForm({ onSubmit, initialValue = "" }: Props) {
+  const [value, setValue] = useState(initialValue);
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed);
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-3 sm:flex-row sm:items-end"
+    >
+      <div className="flex-1 space-y-2">
+        <Label htmlFor="github-username">GitHub ユーザー名</Label>
+        <Input
+          id="github-username"
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="例: facebook"
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </div>
+      <Button type="submit" disabled={!value.trim()}>
+        <Search className="size-4" aria-hidden="true" />
+        検索
+      </Button>
+    </form>
+  );
+}

--- a/src/features/github-repo-analyzer/lib/__tests__/format.test.ts
+++ b/src/features/github-repo-analyzer/lib/__tests__/format.test.ts
@@ -1,0 +1,93 @@
+import {
+  computeLanguagePercentages,
+  formatCount,
+  formatRelativeDate,
+} from "../format";
+
+describe("formatCount", () => {
+  it("returns the value as-is below 1000", () => {
+    expect(formatCount(0)).toBe("0");
+    expect(formatCount(999)).toBe("999");
+  });
+
+  it("formats thousands with one decimal place", () => {
+    expect(formatCount(1234)).toBe("1.2k");
+    expect(formatCount(9999)).toBe("10k");
+  });
+
+  it("formats large thousands without decimals", () => {
+    expect(formatCount(15_000)).toBe("15k");
+    expect(formatCount(123_456)).toBe("123k");
+  });
+
+  it("formats millions with one decimal place", () => {
+    expect(formatCount(1_500_000)).toBe("1.5M");
+    expect(formatCount(2_000_000)).toBe("2M");
+  });
+
+  it("returns 0 for negative or non-finite values", () => {
+    expect(formatCount(-1)).toBe("0");
+    expect(formatCount(Number.NaN)).toBe("0");
+  });
+});
+
+describe("formatRelativeDate", () => {
+  const now = new Date("2026-05-02T12:00:00Z");
+
+  it("returns 数秒前 for under one minute", () => {
+    expect(
+      formatRelativeDate("2026-05-02T11:59:30Z", now)
+    ).toBe("数秒前");
+  });
+
+  it("returns minutes for under one hour", () => {
+    expect(formatRelativeDate("2026-05-02T11:30:00Z", now)).toBe("30分前");
+  });
+
+  it("returns hours for under one day", () => {
+    expect(formatRelativeDate("2026-05-02T05:00:00Z", now)).toBe("7時間前");
+  });
+
+  it("returns 昨日 for one day ago", () => {
+    expect(formatRelativeDate("2026-05-01T12:00:00Z", now)).toBe("昨日");
+  });
+
+  it("returns days for under 30 days", () => {
+    expect(formatRelativeDate("2026-04-22T12:00:00Z", now)).toBe("10日前");
+  });
+
+  it("returns months for under one year", () => {
+    expect(formatRelativeDate("2026-01-02T12:00:00Z", now)).toBe("4ヶ月前");
+  });
+
+  it("returns years for over one year", () => {
+    expect(formatRelativeDate("2024-05-02T12:00:00Z", now)).toBe("2年前");
+  });
+
+  it("returns the original string when the date is invalid", () => {
+    expect(formatRelativeDate("not-a-date", now)).toBe("not-a-date");
+  });
+});
+
+describe("computeLanguagePercentages", () => {
+  it("returns empty array for empty input", () => {
+    expect(computeLanguagePercentages({})).toEqual([]);
+  });
+
+  it("calculates percentages and sorts by bytes descending", () => {
+    const result = computeLanguagePercentages({
+      TypeScript: 6000,
+      JavaScript: 3000,
+      CSS: 1000,
+    });
+    expect(result).toEqual([
+      { language: "TypeScript", bytes: 6000, percentage: 60 },
+      { language: "JavaScript", bytes: 3000, percentage: 30 },
+      { language: "CSS", bytes: 1000, percentage: 10 },
+    ]);
+  });
+
+  it("handles zero total gracefully", () => {
+    expect(computeLanguagePercentages({ Foo: 0 })).toEqual([]);
+  });
+});

--- a/src/features/github-repo-analyzer/lib/__tests__/github-client.test.ts
+++ b/src/features/github-repo-analyzer/lib/__tests__/github-client.test.ts
@@ -1,0 +1,151 @@
+import {
+  GithubApiError,
+  fetchRepoStats,
+  fetchUserRepos,
+} from "../github-client";
+
+describe("fetchUserRepos", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("returns repos on success", async () => {
+    const payload = {
+      repos: [
+        {
+          id: 1,
+          name: "demo",
+          fullName: "facebook/demo",
+          description: null,
+          htmlUrl: "https://github.com/facebook/demo",
+          stargazersCount: 10,
+          forksCount: 2,
+          openIssuesCount: 1,
+          language: "TypeScript",
+          updatedAt: "2026-04-30T00:00:00Z",
+          isFork: false,
+          isArchived: false,
+        },
+      ],
+    };
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(payload),
+    });
+    global.fetch = fetchMock;
+
+    const result = await fetchUserRepos("facebook", "updated");
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("mode=repos")
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("username=facebook")
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("sort=updated")
+    );
+  });
+
+  it("throws GithubApiError with errorCode on validation error", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () =>
+        Promise.resolve({
+          error: "username は1〜39文字の英数字とハイフンで指定してください。",
+          errorCode: "VALIDATION_ERROR",
+        }),
+    });
+
+    const error = await fetchUserRepos("!!", "updated").catch(
+      (e: unknown) => e
+    );
+    expect(error).toBeInstanceOf(GithubApiError);
+    expect((error as GithubApiError).errorCode).toBe("VALIDATION_ERROR");
+    expect((error as GithubApiError).message).toContain("username");
+  });
+
+  it("throws fallback error when response body is not JSON", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: () => Promise.reject(new Error("invalid")),
+    });
+
+    await expect(fetchUserRepos("facebook", "updated")).rejects.toThrow(
+      "リクエストに失敗しました。（502）"
+    );
+  });
+
+  it("propagates RATE_LIMITED errorCode", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: () =>
+        Promise.resolve({
+          error: "GitHub API のレート制限に達しました。",
+          errorCode: "RATE_LIMITED",
+        }),
+    });
+
+    const error = await fetchUserRepos("facebook", "updated").catch(
+      (e: unknown) => e
+    );
+    expect(error).toBeInstanceOf(GithubApiError);
+    expect((error as GithubApiError).errorCode).toBe("RATE_LIMITED");
+  });
+});
+
+describe("fetchRepoStats", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("returns stats on success", async () => {
+    const payload = {
+      languages: { TypeScript: 1000, JavaScript: 500 },
+      openIssueCount: 12,
+      openPullRequestCount: 3,
+    };
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(payload),
+    });
+    global.fetch = fetchMock;
+
+    const result = await fetchRepoStats("facebook", "react");
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("mode=repo-stats")
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("owner=facebook")
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("repo=react")
+    );
+  });
+
+  it("propagates NOT_FOUND errorCode", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: () =>
+        Promise.resolve({
+          error: "指定されたリソースが見つかりませんでした。",
+          errorCode: "NOT_FOUND",
+        }),
+    });
+
+    const error = await fetchRepoStats("facebook", "nope").catch(
+      (e: unknown) => e
+    );
+    expect(error).toBeInstanceOf(GithubApiError);
+    expect((error as GithubApiError).errorCode).toBe("NOT_FOUND");
+  });
+});

--- a/src/features/github-repo-analyzer/lib/format.ts
+++ b/src/features/github-repo-analyzer/lib/format.ts
@@ -18,7 +18,7 @@ export function formatRelativeDate(
 ): string {
   const target = Date.parse(isoDate);
   if (!Number.isFinite(target)) return isoDate;
-  const diffMs = now.getTime() - target;
+  const diffMs = Math.max(0, now.getTime() - target);
   const diffSeconds = Math.floor(diffMs / 1000);
 
   if (diffSeconds < 60) return "数秒前";

--- a/src/features/github-repo-analyzer/lib/format.ts
+++ b/src/features/github-repo-analyzer/lib/format.ts
@@ -1,0 +1,50 @@
+export function formatCount(value: number): string {
+  if (!Number.isFinite(value) || value < 0) return "0";
+  if (value < 1000) return String(value);
+  if (value < 10_000) {
+    const thousands = value / 1000;
+    return `${thousands.toFixed(1).replace(/\.0$/, "")}k`;
+  }
+  if (value < 1_000_000) {
+    return `${Math.floor(value / 1000)}k`;
+  }
+  const millions = value / 1_000_000;
+  return `${millions.toFixed(1).replace(/\.0$/, "")}M`;
+}
+
+export function formatRelativeDate(
+  isoDate: string,
+  now: Date = new Date()
+): string {
+  const target = Date.parse(isoDate);
+  if (!Number.isFinite(target)) return isoDate;
+  const diffMs = now.getTime() - target;
+  const diffSeconds = Math.floor(diffMs / 1000);
+
+  if (diffSeconds < 60) return "数秒前";
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  if (diffMinutes < 60) return `${diffMinutes}分前`;
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}時間前`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays === 1) return "昨日";
+  if (diffDays < 30) return `${diffDays}日前`;
+  const diffMonths = Math.floor(diffDays / 30);
+  if (diffMonths < 12) return `${diffMonths}ヶ月前`;
+  const diffYears = Math.floor(diffDays / 365);
+  return `${diffYears}年前`;
+}
+
+export function computeLanguagePercentages(
+  languages: Record<string, number>
+): Array<{ language: string; bytes: number; percentage: number }> {
+  const total = Object.values(languages).reduce((sum, n) => sum + n, 0);
+  if (total <= 0) return [];
+  return Object.entries(languages)
+    .map(([language, bytes]) => ({
+      language,
+      bytes,
+      percentage: (bytes / total) * 100,
+    }))
+    .sort((a, b) => b.bytes - a.bytes);
+}

--- a/src/features/github-repo-analyzer/lib/github-client.ts
+++ b/src/features/github-repo-analyzer/lib/github-client.ts
@@ -1,0 +1,53 @@
+import type {
+  ApiErrorCode,
+  RepoStats,
+  RepoSummary,
+  SortKey,
+} from "./types";
+
+export class GithubApiError extends Error {
+  readonly errorCode: ApiErrorCode | undefined;
+
+  constructor(message: string, errorCode?: ApiErrorCode) {
+    super(message);
+    this.name = "GithubApiError";
+    this.errorCode = errorCode;
+  }
+}
+
+async function request<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    const message =
+      body?.error ?? `リクエストに失敗しました。（${res.status}）`;
+    throw new GithubApiError(message, body?.errorCode);
+  }
+  return res.json() as Promise<T>;
+}
+
+export function fetchUserRepos(
+  username: string,
+  sort: SortKey
+): Promise<{ repos: RepoSummary[] }> {
+  const params = new URLSearchParams({
+    mode: "repos",
+    username,
+    sort,
+  });
+  return request<{ repos: RepoSummary[] }>(
+    `/api/github?${params.toString()}`
+  );
+}
+
+export function fetchRepoStats(
+  owner: string,
+  repo: string
+): Promise<RepoStats> {
+  const params = new URLSearchParams({
+    mode: "repo-stats",
+    owner,
+    repo,
+  });
+  return request<RepoStats>(`/api/github?${params.toString()}`);
+}

--- a/src/features/github-repo-analyzer/lib/types.ts
+++ b/src/features/github-repo-analyzer/lib/types.ts
@@ -1,0 +1,31 @@
+export type ApiErrorCode =
+  | "VALIDATION_ERROR"
+  | "RATE_LIMITED"
+  | "NOT_FOUND"
+  | "UPSTREAM_ERROR"
+  | "SERVER_ERROR";
+
+export type RepoSummary = {
+  id: number;
+  name: string;
+  fullName: string;
+  description: string | null;
+  htmlUrl: string;
+  stargazersCount: number;
+  forksCount: number;
+  openIssuesCount: number;
+  language: string | null;
+  updatedAt: string;
+  isFork: boolean;
+  isArchived: boolean;
+};
+
+export type LanguageBreakdown = Record<string, number>;
+
+export type RepoStats = {
+  languages: LanguageBreakdown;
+  openIssueCount: number;
+  openPullRequestCount: number;
+};
+
+export type SortKey = "updated" | "stars";

--- a/src/features/github-repo-analyzer/lib/use-github-repos.ts
+++ b/src/features/github-repo-analyzer/lib/use-github-repos.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { GithubApiError, fetchUserRepos } from "./github-client";
+import type { ApiErrorCode, RepoSummary, SortKey } from "./types";
+
+type ErrorState = {
+  message: string;
+  errorCode?: ApiErrorCode;
+};
+
+function toErrorState(e: unknown): ErrorState {
+  if (e instanceof GithubApiError) {
+    return { message: e.message, errorCode: e.errorCode };
+  }
+  return {
+    message:
+      e instanceof Error ? e.message : "リポジトリの取得に失敗しました。",
+  };
+}
+
+export function useGithubRepos(username: string, sort: SortKey) {
+  const key = `${username}|${sort}`;
+  const [result, setResult] = useState<
+    { data: RepoSummary[]; key: string } | null
+  >(null);
+  const [errorState, setErrorState] = useState<
+    { error: ErrorState; key: string } | null
+  >(null);
+
+  useEffect(() => {
+    if (!username) return;
+    let cancelled = false;
+    fetchUserRepos(username, sort)
+      .then(({ repos }) => {
+        if (cancelled) return;
+        setResult({ data: repos, key });
+        setErrorState(null);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setErrorState({ error: toErrorState(e), key });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [username, sort, key]);
+
+  const repos = result && result.key === key ? result.data : null;
+  const error =
+    errorState && errorState.key === key ? errorState.error : null;
+  const loading = username !== "" && repos === null && error === null;
+
+  return { repos, error, loading };
+}

--- a/src/features/github-repo-analyzer/lib/use-repo-stats.ts
+++ b/src/features/github-repo-analyzer/lib/use-repo-stats.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { GithubApiError, fetchRepoStats } from "./github-client";
+import type { ApiErrorCode, RepoStats } from "./types";
+
+type ErrorState = {
+  message: string;
+  errorCode?: ApiErrorCode;
+};
+
+function toErrorState(e: unknown): ErrorState {
+  if (e instanceof GithubApiError) {
+    return { message: e.message, errorCode: e.errorCode };
+  }
+  return {
+    message:
+      e instanceof Error ? e.message : "統計情報の取得に失敗しました。",
+  };
+}
+
+export function useRepoStats(owner: string | null, repo: string | null) {
+  const key = owner && repo ? `${owner}/${repo}` : "";
+  const [result, setResult] = useState<{ data: RepoStats; key: string } | null>(
+    null
+  );
+  const [errorState, setErrorState] = useState<
+    { error: ErrorState; key: string } | null
+  >(null);
+
+  useEffect(() => {
+    if (!owner || !repo) return;
+    let cancelled = false;
+    fetchRepoStats(owner, repo)
+      .then((data) => {
+        if (cancelled) return;
+        setResult({ data, key });
+        setErrorState(null);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setErrorState({ error: toErrorState(e), key });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [owner, repo, key]);
+
+  const stats = result && result.key === key ? result.data : null;
+  const error =
+    errorState && errorState.key === key ? errorState.error : null;
+  const loading = key !== "" && stats === null && error === null;
+
+  return { stats, error, loading };
+}


### PR DESCRIPTION
## Summary

- 新規ツール `/tools/github-repo-analyzer` を `external-api` カテゴリに追加
- ユーザー名で公開リポジトリ一覧を取得し、スター数 / フォーク数 / 言語 / 更新日を表示
- 詳細パネルで言語比率（カラーバー）と Open Issue / Open PR 数を表示
- 並び替え（更新日 / スター数）に対応
- `/api/github` (`mode=repos` / `mode=repo-stats`) を経由してレート制限・エラー正規化をサーバー側で集約（既存の `/api/exchange-rate` パターンを踏襲）
- ロジック層に Jest テスト 2 ファイル / 18 ケースを追加

## 補足

Issue #36 では 5 つのサブ機能が挙げられていましたが、レビュー負荷とレート制限の観点から MVP に絞り、以下は別 Issue (#185 / #186 / #187) に分離しました:
- コントリビューション頻度ヒートマップ（GraphQL 認証必須）
- Issue/PR 平均クローズ時間（多数の API 呼び出しが必要）
- お気に入り保存（localStorage）

ファイル数 16 / +1216 行は規約の上限を超えますが、変更は新ツールの新規ファイル群が中心のため新機能例外に該当します。

Closes #36

## Test plan

- [ ] `npm run lint` が成功
- [ ] `npm run test` が成功（552 件）
- [ ] `npm run build` が成功
- [ ] `npm run dev` でブラウザ確認
  - [ ] `/tools/github-repo-analyzer` でユーザー名（例: `facebook`）を入力 → リポジトリ一覧が表示される
  - [ ] 存在しないユーザー → 404 メッセージが Alert に表示
  - [ ] リポジトリを選択 → 詳細パネルに言語比率と Open Issue/PR 数が表示
  - [ ] 並び替え（更新日 / スター数）が機能する
  - [ ] レート制限到達時に 429 メッセージが表示される
  - [ ] ダーク / ライトモード切替で崩れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)