### PR TITLE
docs: README の Tools セクションを簡略化

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,7 @@ A collection of personal utility tools built with Next.js.
 
 ## Tools
 
-| Tool | Description | Path |
-|------|-------------|------|
-| UUID Generator | Generate UUID v4/v7 and ULID with bulk generation and clipboard copy | `/tools/uuid-generator` |
-| Text Rewriter | Rewrite text with tone conversion, translation, summarization, and proofreading (powered by Gemini) | `/tools/text-rewriter` |
-| JSON Formatter | Format, minify, validate JSON with tree view and path filter | `/tools/json-formatter` |
+A list of all available tools is shown on the top page after running `npm run dev`. The source for each tool lives under `src/app/tools/`, and the registry is the `tools` array in [`src/app/page.tsx`](src/app/page.tsx).
 
 ## Tech Stack
 

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -8,11 +8,7 @@
 
 ## ツール
 
-| ツール | 説明 | パス |
-|--------|------|------|
-| UUID Generator | UUID v4/v7とULIDを生成。一括生成とクリップボードコピーに対応 | `/tools/uuid-generator` |
-| Text Rewriter | トーン変換・翻訳・要約・校正によるテキスト書き換え（Gemini搭載） | `/tools/text-rewriter` |
-| JSON Formatter | JSONのフォーマット・圧縮・検証。ツリービューとパスフィルター付き | `/tools/json-formatter` |
+`npm run dev` 後、トップページにすべてのツール一覧が表示されます。各ツールのソースは `src/app/tools/` 配下、登録は [`src/app/page.tsx`](../../src/app/page.tsx) の `tools` 配列で管理されています。
 
 ## 技術スタック
 


### PR DESCRIPTION
## Summary
- `README.md` と `docs/ja-JP/README.md` の `## Tools` / `## ツール` セクションの表を、トップページと `src/app/page.tsx` への案内文に置き換え
- ツール一覧の二重管理を解消（実態17ツールに対して表は3ツールしか反映されていなかった）

Closes #189

## Test plan
- [ ] GitHub 上で README.md と docs/ja-JP/README.md の `## Tools` / `## ツール` セクションが案内文に置き換わっている
- [ ] `[\`src/app/page.tsx\`](src/app/page.tsx)` のリンクが GitHub 上で正しく動作する
- [ ] 他のセクション（Tech Stack / Setup / Claude Code Setup / Docs）は変更されていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)