### PR TITLE
feat: IP Info Viewer (MVP) を追加

### DIFF
--- a/src/app/api/ip-info/route.ts
+++ b/src/app/api/ip-info/route.ts
@@ -7,7 +7,7 @@ const IPAPI_BASE = "https://ipapi.co";
 const USER_AGENT = "personal-tools";
 
 const IPV4_PATTERN = /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d?\d)$/;
-const IPV6_PATTERN = /^[0-9a-fA-F:]+$/;
+const IPV6_HEXTET_PATTERN = /^[0-9a-fA-F]{1,4}$/;
 
 const ALLOWED_HEADERS = [
   "user-agent",
@@ -134,7 +134,24 @@ async function fetchUpstream(
 }
 
 function isValidIp(value: string): boolean {
-  return IPV4_PATTERN.test(value) || (value.includes(":") && IPV6_PATTERN.test(value));
+  if (IPV4_PATTERN.test(value)) return true;
+  if (!value.includes(":")) return false;
+  return isValidIpv6(value);
+}
+
+function isValidIpv6(value: string): boolean {
+  const dcParts = value.split("::");
+  if (dcParts.length > 2) return false;
+
+  if (dcParts.length === 2) {
+    const left = dcParts[0] === "" ? [] : dcParts[0].split(":");
+    const right = dcParts[1] === "" ? [] : dcParts[1].split(":");
+    if (left.length + right.length > 7) return false;
+    return [...left, ...right].every((g) => IPV6_HEXTET_PATTERN.test(g));
+  }
+
+  const groups = value.split(":");
+  return groups.length === 8 && groups.every((g) => IPV6_HEXTET_PATTERN.test(g));
 }
 
 function isReservedIp(value: string): boolean {
@@ -145,6 +162,7 @@ function isReservedIp(value: string): boolean {
   if (parts.length !== 4 || parts.some((n) => Number.isNaN(n))) return false;
   const [a, b] = parts;
   if (a === 10 || a === 127) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
   if (a === 172 && b >= 16 && b <= 31) return true;
   if (a === 192 && b === 168) return true;
   if (a === 169 && b === 254) return true;

--- a/src/app/api/ip-info/route.ts
+++ b/src/app/api/ip-info/route.ts
@@ -1,0 +1,213 @@
+import { NextResponse } from "next/server";
+import { createRateLimit } from "@/lib/rate-limit";
+import { getClientIp, rateLimitResponse } from "@/lib/api-helpers";
+import type { IpInfo, IpVersion } from "@/features/ip-info-viewer/lib/types";
+
+const IPAPI_BASE = "https://ipapi.co";
+const USER_AGENT = "personal-tools";
+
+const IPV4_PATTERN = /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d?\d)$/;
+const IPV6_PATTERN = /^[0-9a-fA-F:]+$/;
+
+const ALLOWED_HEADERS = [
+  "user-agent",
+  "accept",
+  "accept-language",
+  "accept-encoding",
+  "sec-ch-ua",
+  "sec-ch-ua-mobile",
+  "sec-ch-ua-platform",
+  "dnt",
+  "upgrade-insecure-requests",
+  "referer",
+  "connection",
+] as const;
+
+const rateLimit = createRateLimit({ limit: 30, windowMs: 60_000 });
+
+export async function GET(request: Request) {
+  const ip = getClientIp(request);
+  if (ip !== "unknown") {
+    const result = rateLimit.check(ip);
+    if (!result.allowed) {
+      return rateLimitResponse(result.retryAfterMs);
+    }
+  }
+
+  const { searchParams } = new URL(request.url);
+  const mode = searchParams.get("mode");
+
+  if (mode === "self") {
+    return handleSelf(request, ip);
+  }
+  if (mode === "lookup") {
+    return handleLookup(searchParams);
+  }
+  return validationError("mode は self / lookup のいずれかを指定してください。");
+}
+
+async function handleSelf(request: Request, clientIp: string): Promise<Response> {
+  const url =
+    clientIp !== "unknown" && isValidIp(clientIp) && !isReservedIp(clientIp)
+      ? new URL(`${IPAPI_BASE}/${clientIp}/json/`)
+      : new URL(`${IPAPI_BASE}/json/`);
+
+  const upstream = await fetchUpstream(url, "IP情報の取得に失敗しました。");
+  if (!upstream.ok) return upstream.errorResponse;
+
+  const raw = (await upstream.response.json()) as IpapiResponse;
+  if (raw.error) {
+    return validationError(raw.reason ?? "IPアドレス情報を取得できませんでした。");
+  }
+
+  const headers = pickHeaders(request.headers);
+  return NextResponse.json({ geo: toIpInfo(raw), headers });
+}
+
+async function handleLookup(params: URLSearchParams): Promise<Response> {
+  const ip = (params.get("ip") ?? "").trim();
+  if (!isValidIp(ip)) {
+    return validationError("IPアドレスの形式が正しくありません。");
+  }
+
+  const url = new URL(`${IPAPI_BASE}/${ip}/json/`);
+  const upstream = await fetchUpstream(url, "IP情報の取得に失敗しました。");
+  if (!upstream.ok) return upstream.errorResponse;
+
+  const raw = (await upstream.response.json()) as IpapiResponse;
+  if (raw.error) {
+    return validationError(raw.reason ?? "IPアドレス情報を取得できませんでした。");
+  }
+
+  return NextResponse.json({ geo: toIpInfo(raw) });
+}
+
+type UpstreamResult =
+  | { ok: true; response: Response }
+  | { ok: false; errorResponse: Response };
+
+async function fetchUpstream(
+  url: URL,
+  failureMessage: string
+): Promise<UpstreamResult> {
+  let upstream: Response;
+  try {
+    upstream = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": USER_AGENT,
+      },
+    });
+  } catch {
+    return {
+      ok: false,
+      errorResponse: NextResponse.json(
+        { error: "IP情報サービスに接続できませんでした。", errorCode: "UPSTREAM_ERROR" },
+        { status: 502 }
+      ),
+    };
+  }
+
+  if (!upstream.ok) {
+    if (upstream.status === 429) {
+      return {
+        ok: false,
+        errorResponse: NextResponse.json(
+          {
+            error: "IP情報サービスのレート制限に達しました。しばらく経ってから再度お試しください。",
+            errorCode: "RATE_LIMITED",
+          },
+          { status: 429 }
+        ),
+      };
+    }
+    return {
+      ok: false,
+      errorResponse: NextResponse.json(
+        { error: failureMessage, errorCode: "UPSTREAM_ERROR" },
+        { status: 502 }
+      ),
+    };
+  }
+
+  return { ok: true, response: upstream };
+}
+
+function isValidIp(value: string): boolean {
+  return IPV4_PATTERN.test(value) || (value.includes(":") && IPV6_PATTERN.test(value));
+}
+
+function isReservedIp(value: string): boolean {
+  if (value === "::1" || value.startsWith("fe80:") || value.startsWith("fc") || value.startsWith("fd")) {
+    return true;
+  }
+  const parts = value.split(".").map((n) => Number.parseInt(n, 10));
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n))) return false;
+  const [a, b] = parts;
+  if (a === 10 || a === 127) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 169 && b === 254) return true;
+  return false;
+}
+
+function pickHeaders(headers: Headers): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const name of ALLOWED_HEADERS) {
+    const value = headers.get(name);
+    if (value) {
+      result[name] = value;
+    }
+  }
+  return result;
+}
+
+function toIpInfo(raw: IpapiResponse): IpInfo {
+  const version = normalizeVersion(raw.version);
+  return {
+    ip: raw.ip ?? "",
+    version,
+    city: raw.city ?? null,
+    region: raw.region ?? null,
+    countryCode: raw.country_code ?? raw.country ?? null,
+    countryName: raw.country_name ?? null,
+    postal: raw.postal ?? null,
+    latitude: typeof raw.latitude === "number" ? raw.latitude : null,
+    longitude: typeof raw.longitude === "number" ? raw.longitude : null,
+    timezone: raw.timezone ?? null,
+    utcOffset: raw.utc_offset ?? null,
+    org: raw.org ?? null,
+    asn: raw.asn ?? null,
+  };
+}
+
+function normalizeVersion(value: string | undefined): IpVersion | null {
+  if (value === "IPv4" || value === "IPv6") return value;
+  return null;
+}
+
+function validationError(message: string): Response {
+  return NextResponse.json(
+    { error: message, errorCode: "VALIDATION_ERROR" },
+    { status: 400 }
+  );
+}
+
+type IpapiResponse = {
+  ip?: string;
+  version?: string;
+  city?: string;
+  region?: string;
+  country?: string;
+  country_code?: string;
+  country_name?: string;
+  postal?: string;
+  latitude?: number;
+  longitude?: number;
+  timezone?: string;
+  utc_offset?: string;
+  org?: string;
+  asn?: string;
+  error?: boolean;
+  reason?: string;
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, ArrowLeftRight, Braces, Calculator, Clock, Cloud, Coins, FileText, Fingerprint, FileDiff, Github, Languages, Palette, Package, QrCode, Regex, Timer, Type, type LucideIcon } from "lucide-react";
+import { ArrowRight, ArrowLeftRight, Braces, Calculator, Clock, Cloud, Coins, FileText, Fingerprint, FileDiff, Github, Globe, Languages, Palette, Package, QrCode, Regex, Timer, Type, type LucideIcon } from "lucide-react";
 import {
   Card,
   CardHeader,
@@ -144,6 +144,13 @@ const tools: Tool[] = [
     description: "GitHubユーザーの公開リポジトリ一覧と統計を可視化",
     href: "/tools/github-repo-analyzer",
     icon: Github,
+    category: "external-api",
+  },
+  {
+    name: "IP Info Viewer",
+    description: "自分のグローバルIPとジオロケーション、ISP・タイムゾーンなどを表示",
+    href: "/tools/ip-info-viewer",
+    icon: Globe,
     category: "external-api",
   },
 ];

--- a/src/app/tools/ip-info-viewer/page.tsx
+++ b/src/app/tools/ip-info-viewer/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { IpInfoViewerPage } from "@/features/ip-info-viewer/components/ip-info-viewer-page";
+
+export const metadata: Metadata = {
+  title: "IP Info Viewer - Personal Tools",
+  description:
+    "自分のグローバルIPとジオロケーション、ISP・タイムゾーン、HTTPリクエストヘッダーを表示",
+};
+
+export default function Page() {
+  return <IpInfoViewerPage />;
+}

--- a/src/features/ip-info-viewer/components/headers-table.tsx
+++ b/src/features/ip-info-viewer/components/headers-table.tsx
@@ -1,0 +1,52 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+type Props = {
+  headers: Record<string, string>;
+};
+
+const HEADER_LABELS: Record<string, string> = {
+  "user-agent": "User-Agent",
+  accept: "Accept",
+  "accept-language": "Accept-Language",
+  "accept-encoding": "Accept-Encoding",
+  "sec-ch-ua": "Sec-CH-UA",
+  "sec-ch-ua-mobile": "Sec-CH-UA-Mobile",
+  "sec-ch-ua-platform": "Sec-CH-UA-Platform",
+  dnt: "DNT",
+  "upgrade-insecure-requests": "Upgrade-Insecure-Requests",
+  referer: "Referer",
+  connection: "Connection",
+};
+
+export function HeadersTable({ headers }: Props) {
+  const entries = Object.entries(headers);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">HTTPヘッダー</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          このページへのリクエストでブラウザが送信した主要ヘッダー一覧です。
+        </p>
+      </CardHeader>
+      <CardContent>
+        {entries.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            表示できるヘッダーはありませんでした。
+          </p>
+        ) : (
+          <dl className="grid gap-x-6 gap-y-2 text-sm sm:grid-cols-[max-content_1fr]">
+            {entries.map(([name, value]) => (
+              <div key={name} className="contents">
+                <dt className="text-muted-foreground">
+                  {HEADER_LABELS[name] ?? name}
+                </dt>
+                <dd className="break-all font-mono text-xs sm:text-sm">{value}</dd>
+              </div>
+            ))}
+          </dl>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/ip-info-viewer/components/headers-table.tsx
+++ b/src/features/ip-info-viewer/components/headers-table.tsx
@@ -26,7 +26,7 @@ export function HeadersTable({ headers }: Props) {
       <CardHeader>
         <CardTitle className="text-lg">HTTPヘッダー</CardTitle>
         <p className="text-sm text-muted-foreground">
-          このページへのリクエストでブラウザが送信した主要ヘッダー一覧です。
+          IP情報取得APIへのリクエスト時にブラウザが送信した主要ヘッダー一覧です。
         </p>
       </CardHeader>
       <CardContent>

--- a/src/features/ip-info-viewer/components/ip-info-card.tsx
+++ b/src/features/ip-info-viewer/components/ip-info-card.tsx
@@ -1,0 +1,79 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  formatCoordinates,
+  formatLocation,
+  formatTimezone,
+} from "../lib/format";
+import type { IpInfo } from "../lib/types";
+
+type Props = {
+  info: IpInfo;
+  title?: string;
+};
+
+export function IpInfoCard({ info, title }: Props) {
+  const coords = formatCoordinates(info);
+  const tz = formatTimezone(info);
+  const mapHref =
+    coords && info.latitude !== null && info.longitude !== null
+      ? `https://www.openstreetmap.org/?mlat=${info.latitude}&mlon=${info.longitude}#map=10/${info.latitude}/${info.longitude}`
+      : null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <span className="font-mono">{info.ip || "不明"}</span>
+          {info.version && <Badge variant="secondary">{info.version}</Badge>}
+        </CardTitle>
+        {title && (
+          <p className="text-sm text-muted-foreground">{title}</p>
+        )}
+      </CardHeader>
+      <CardContent>
+        <dl className="grid gap-x-6 gap-y-2 text-sm sm:grid-cols-[max-content_1fr]">
+          <DataRow label="場所" value={formatLocation(info)} />
+          {info.postal && <DataRow label="郵便番号" value={info.postal} />}
+          {tz && <DataRow label="タイムゾーン" value={tz} />}
+          {info.org && <DataRow label="ISP / 組織" value={info.org} />}
+          {info.asn && <DataRow label="ASN" value={info.asn} />}
+          {coords && (
+            <DataRow
+              label="緯度経度"
+              value={
+                mapHref ? (
+                  <a
+                    href={mapHref}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline-offset-2 hover:underline"
+                  >
+                    {coords}
+                  </a>
+                ) : (
+                  coords
+                )
+              }
+            />
+          )}
+        </dl>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DataRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: React.ReactNode;
+}) {
+  return (
+    <>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="break-words">{value}</dd>
+    </>
+  );
+}

--- a/src/features/ip-info-viewer/components/ip-info-viewer-page.tsx
+++ b/src/features/ip-info-viewer/components/ip-info-viewer-page.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { AlertCircle, Loader2, Search } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useIpInfo } from "../lib/use-ip-info";
+import { HeadersTable } from "./headers-table";
+import { IpInfoCard } from "./ip-info-card";
+
+export function IpInfoViewerPage() {
+  const { self, selfError, selfLoading, lookupState, lookup } = useIpInfo();
+  const [ipInput, setIpInput] = useState("");
+
+  const handleLookupSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    lookup(ipInput);
+  };
+
+  const lookupLoading = lookupState.status === "loading";
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">IP Info Viewer</h1>
+        <p className="mt-2 text-muted-foreground">
+          自分のグローバルIPとジオロケーション、HTTPリクエストヘッダーを表示します。任意のIPアドレスの情報も検索できます（ipapi.co、レート制限30req/min）。
+        </p>
+      </div>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold tracking-tight">自分のIP情報</h2>
+        {selfLoading && (
+          <div className="space-y-3">
+            <Skeleton className="h-40 w-full" />
+            <Skeleton className="h-40 w-full" />
+          </div>
+        )}
+        {selfError && (
+          <Alert variant="destructive" role="alert">
+            <AlertCircle className="size-4" />
+            <AlertTitle>自分のIP情報の取得に失敗しました</AlertTitle>
+            <AlertDescription>{selfError.message}</AlertDescription>
+          </Alert>
+        )}
+        {self && (
+          <div className="space-y-4">
+            <IpInfoCard info={self.geo} />
+            <HeadersTable headers={self.headers} />
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold tracking-tight">任意のIPを検索</h2>
+        <form
+          onSubmit={handleLookupSubmit}
+          className="flex flex-col gap-3 sm:flex-row sm:items-end"
+        >
+          <div className="flex-1 space-y-2">
+            <Label htmlFor="ip-lookup">IPアドレス</Label>
+            <Input
+              id="ip-lookup"
+              type="text"
+              value={ipInput}
+              onChange={(e) => setIpInput(e.target.value)}
+              placeholder="例: 8.8.8.8"
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+          <Button type="submit" disabled={!ipInput.trim() || lookupLoading}>
+            {lookupLoading ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <Search className="size-4" aria-hidden="true" />
+            )}
+            検索
+          </Button>
+        </form>
+
+        {lookupState.status === "loading" && (
+          <Skeleton className="h-40 w-full" />
+        )}
+        {lookupState.status === "error" && (
+          <Alert variant="destructive" role="alert">
+            <AlertCircle className="size-4" />
+            <AlertTitle>IPアドレス情報の取得に失敗しました</AlertTitle>
+            <AlertDescription>{lookupState.error.message}</AlertDescription>
+          </Alert>
+        )}
+        {lookupState.status === "success" && (
+          <IpInfoCard info={lookupState.data} />
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/features/ip-info-viewer/lib/__tests__/ip-info-client.test.ts
+++ b/src/features/ip-info-viewer/lib/__tests__/ip-info-client.test.ts
@@ -1,0 +1,134 @@
+import {
+  IpInfoError,
+  fetchLookup,
+  fetchSelfInfo,
+} from "../ip-info-client";
+
+const sampleGeo = {
+  ip: "8.8.8.8",
+  version: "IPv4" as const,
+  city: "Mountain View",
+  region: "California",
+  countryCode: "US",
+  countryName: "United States",
+  postal: "94043",
+  latitude: 37.4056,
+  longitude: -122.0775,
+  timezone: "America/Los_Angeles",
+  utcOffset: "-0700",
+  org: "GOOGLE",
+  asn: "AS15169",
+};
+
+describe("fetchSelfInfo", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("returns geo and headers on success", async () => {
+    const payload = {
+      geo: sampleGeo,
+      headers: { "user-agent": "Mozilla/5.0" },
+    };
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(payload),
+    });
+    global.fetch = fetchMock;
+
+    const result = await fetchSelfInfo();
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("mode=self")
+    );
+  });
+
+  it("throws IpInfoError with errorCode on upstream error", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: () =>
+        Promise.resolve({
+          error: "IP情報サービスに接続できませんでした。",
+          errorCode: "UPSTREAM_ERROR",
+        }),
+    });
+
+    const error = await fetchSelfInfo().catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(IpInfoError);
+    expect((error as IpInfoError).errorCode).toBe("UPSTREAM_ERROR");
+  });
+
+  it("propagates RATE_LIMITED errorCode", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: () =>
+        Promise.resolve({
+          error: "リクエストが多すぎます。",
+          errorCode: "RATE_LIMITED",
+        }),
+    });
+
+    const error = await fetchSelfInfo().catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(IpInfoError);
+    expect((error as IpInfoError).errorCode).toBe("RATE_LIMITED");
+  });
+});
+
+describe("fetchLookup", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("returns geo on success and passes ip in query", async () => {
+    const payload = { geo: sampleGeo };
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(payload),
+    });
+    global.fetch = fetchMock;
+
+    const result = await fetchLookup("8.8.8.8");
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("mode=lookup")
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("ip=8.8.8.8")
+    );
+  });
+
+  it("throws IpInfoError with VALIDATION_ERROR on bad input", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () =>
+        Promise.resolve({
+          error: "IPアドレスの形式が正しくありません。",
+          errorCode: "VALIDATION_ERROR",
+        }),
+    });
+
+    const error = await fetchLookup("not-an-ip").catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(IpInfoError);
+    expect((error as IpInfoError).errorCode).toBe("VALIDATION_ERROR");
+    expect((error as IpInfoError).message).toContain("IPアドレス");
+  });
+
+  it("throws fallback error when response body is not JSON", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.reject(new Error("invalid")),
+    });
+
+    await expect(fetchLookup("8.8.8.8")).rejects.toThrow(
+      "リクエストに失敗しました。（500）"
+    );
+  });
+});

--- a/src/features/ip-info-viewer/lib/format.ts
+++ b/src/features/ip-info-viewer/lib/format.ts
@@ -1,0 +1,18 @@
+import type { IpInfo } from "./types";
+
+export function formatLocation(info: IpInfo): string {
+  const parts = [info.city, info.region, info.countryName].filter(
+    (part): part is string => Boolean(part)
+  );
+  return parts.length > 0 ? parts.join(", ") : "不明";
+}
+
+export function formatCoordinates(info: IpInfo): string | null {
+  if (info.latitude === null || info.longitude === null) return null;
+  return `${info.latitude.toFixed(4)}, ${info.longitude.toFixed(4)}`;
+}
+
+export function formatTimezone(info: IpInfo): string | null {
+  if (!info.timezone) return null;
+  return info.utcOffset ? `${info.timezone} (UTC${info.utcOffset})` : info.timezone;
+}

--- a/src/features/ip-info-viewer/lib/ip-info-client.ts
+++ b/src/features/ip-info-viewer/lib/ip-info-client.ts
@@ -1,0 +1,36 @@
+import type {
+  ApiErrorCode,
+  LookupResponse,
+  SelfInfoResponse,
+} from "./types";
+
+export class IpInfoError extends Error {
+  readonly errorCode: ApiErrorCode | undefined;
+
+  constructor(message: string, errorCode?: ApiErrorCode) {
+    super(message);
+    this.name = "IpInfoError";
+    this.errorCode = errorCode;
+  }
+}
+
+async function request<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    const message =
+      body?.error ?? `リクエストに失敗しました。（${res.status}）`;
+    throw new IpInfoError(message, body?.errorCode);
+  }
+  return res.json() as Promise<T>;
+}
+
+export function fetchSelfInfo(): Promise<SelfInfoResponse> {
+  const params = new URLSearchParams({ mode: "self" });
+  return request<SelfInfoResponse>(`/api/ip-info?${params.toString()}`);
+}
+
+export function fetchLookup(ip: string): Promise<LookupResponse> {
+  const params = new URLSearchParams({ mode: "lookup", ip });
+  return request<LookupResponse>(`/api/ip-info?${params.toString()}`);
+}

--- a/src/features/ip-info-viewer/lib/types.ts
+++ b/src/features/ip-info-viewer/lib/types.ts
@@ -1,0 +1,33 @@
+export type ApiErrorCode =
+  | "VALIDATION_ERROR"
+  | "RATE_LIMITED"
+  | "NOT_FOUND"
+  | "UPSTREAM_ERROR"
+  | "SERVER_ERROR";
+
+export type IpVersion = "IPv4" | "IPv6";
+
+export type IpInfo = {
+  ip: string;
+  version: IpVersion | null;
+  city: string | null;
+  region: string | null;
+  countryCode: string | null;
+  countryName: string | null;
+  postal: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  timezone: string | null;
+  utcOffset: string | null;
+  org: string | null;
+  asn: string | null;
+};
+
+export type SelfInfoResponse = {
+  geo: IpInfo;
+  headers: Record<string, string>;
+};
+
+export type LookupResponse = {
+  geo: IpInfo;
+};

--- a/src/features/ip-info-viewer/lib/use-ip-info.ts
+++ b/src/features/ip-info-viewer/lib/use-ip-info.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { IpInfoError, fetchLookup, fetchSelfInfo } from "./ip-info-client";
 import type {
   ApiErrorCode,
@@ -33,6 +33,7 @@ export function useIpInfo() {
   const [selfError, setSelfError] = useState<ErrorState | null>(null);
   const [selfLoading, setSelfLoading] = useState(true);
   const [lookupState, setLookupState] = useState<LookupState>({ status: "idle" });
+  const lookupRequestIdRef = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -58,12 +59,16 @@ export function useIpInfo() {
   const lookup = useCallback((ip: string) => {
     const trimmed = ip.trim();
     if (!trimmed) return;
+    const requestId = lookupRequestIdRef.current + 1;
+    lookupRequestIdRef.current = requestId;
     setLookupState({ status: "loading", ip: trimmed });
     fetchLookup(trimmed)
       .then(({ geo }) => {
+        if (lookupRequestIdRef.current !== requestId) return;
         setLookupState({ status: "success", ip: trimmed, data: geo });
       })
       .catch((e: unknown) => {
+        if (lookupRequestIdRef.current !== requestId) return;
         setLookupState({
           status: "error",
           ip: trimmed,

--- a/src/features/ip-info-viewer/lib/use-ip-info.ts
+++ b/src/features/ip-info-viewer/lib/use-ip-info.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { IpInfoError, fetchLookup, fetchSelfInfo } from "./ip-info-client";
+import type {
+  ApiErrorCode,
+  IpInfo,
+  SelfInfoResponse,
+} from "./types";
+
+type ErrorState = {
+  message: string;
+  errorCode?: ApiErrorCode;
+};
+
+function toErrorState(e: unknown, fallback: string): ErrorState {
+  if (e instanceof IpInfoError) {
+    return { message: e.message, errorCode: e.errorCode };
+  }
+  return {
+    message: e instanceof Error ? e.message : fallback,
+  };
+}
+
+type LookupState =
+  | { status: "idle" }
+  | { status: "loading"; ip: string }
+  | { status: "success"; ip: string; data: IpInfo }
+  | { status: "error"; ip: string; error: ErrorState };
+
+export function useIpInfo() {
+  const [self, setSelf] = useState<SelfInfoResponse | null>(null);
+  const [selfError, setSelfError] = useState<ErrorState | null>(null);
+  const [selfLoading, setSelfLoading] = useState(true);
+  const [lookupState, setLookupState] = useState<LookupState>({ status: "idle" });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchSelfInfo()
+      .then((data) => {
+        if (cancelled) return;
+        setSelf(data);
+        setSelfError(null);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setSelfError(toErrorState(e, "自分のIP情報の取得に失敗しました。"));
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setSelfLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const lookup = useCallback((ip: string) => {
+    const trimmed = ip.trim();
+    if (!trimmed) return;
+    setLookupState({ status: "loading", ip: trimmed });
+    fetchLookup(trimmed)
+      .then(({ geo }) => {
+        setLookupState({ status: "success", ip: trimmed, data: geo });
+      })
+      .catch((e: unknown) => {
+        setLookupState({
+          status: "error",
+          ip: trimmed,
+          error: toErrorState(e, "IPアドレス情報の取得に失敗しました。"),
+        });
+      });
+  }, []);
+
+  return {
+    self,
+    selfError,
+    selfLoading,
+    lookupState,
+    lookup,
+  };
+}


### PR DESCRIPTION
## Summary
- `external-api` カテゴリに IP Info Viewer ツールを追加。ipapi.co を経由して自分の／任意のIPのジオロケーション（国・地域・市・ISP・タイムゾーン・緯度経度）と、リクエストの主要HTTPヘッダーを表示
- `src/app/api/ip-info/route.ts` を新設（`mode=self` / `mode=lookup`、レート制限 30 req/min、ヘッダー allowlist、リザーブドIP時は `/json/` フォールバック）
- 既存の external-api 系ツールと同じ三層構成（route → API route → upstream）に揃え、`IpInfoError` / `fetchSelfInfo` / `fetchLookup` / `useIpInfo` を実装。`ip-info-client` の単体テストを追加

Issue 本文にあった「地図プロット」「DNS Leak チェック」は今回スコープ外（前者は地図ライブラリの導入、後者は専用インフラが必要なため別 Issue 化を推奨）。

Closes #37

## Test plan
- [ ] `npm run lint` / `npm run test` / `npm run build` がパス（ローカルで確認済み）
- [ ] `npm run dev` 起動後 `/tools/ip-info-viewer` を開き、自分のIPカードと HTTPヘッダー一覧が自動表示される
- [ ] 任意IP入力欄に `8.8.8.8` を入れて検索し、Google LLC の情報がカード表示される
- [ ] 不正なIP（例 `abc.def`）入力時にエラーアラートが表示される
- [ ] トップページの「外部API活用」セクションに `IP Info Viewer` カードが追加され、クリックで遷移できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)