### PR TITLE
feat: API Tester (簡易Postman) を追加

### DIFF
--- a/src/app/api/api-tester/route.ts
+++ b/src/app/api/api-tester/route.ts
@@ -1,0 +1,165 @@
+import { NextResponse } from "next/server";
+import { createRateLimit } from "@/lib/rate-limit";
+import { getClientIp, rateLimitResponse } from "@/lib/api-helpers";
+import { validateRequestUrl } from "@/features/api-tester/lib/url-validator";
+import { HTTP_METHODS, type HttpMethod } from "@/features/api-tester/lib/types";
+
+const rateLimit = createRateLimit({ limit: 30, windowMs: 60_000 });
+
+const TIMEOUT_MS = 15_000;
+const MAX_BODY_BYTES = 1_000_000;
+
+const FORBIDDEN_HEADERS = new Set([
+  "host",
+  "connection",
+  "content-length",
+  "transfer-encoding",
+  "upgrade",
+  "expect",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+]);
+
+type RequestBody = {
+  method?: string;
+  url?: string;
+  headers?: Record<string, string>;
+  body?: string | null;
+};
+
+export async function POST(request: Request) {
+  const ip = getClientIp(request);
+  if (ip !== "unknown") {
+    const result = rateLimit.check(ip);
+    if (!result.allowed) {
+      return rateLimitResponse(result.retryAfterMs);
+    }
+  }
+
+  let payload: RequestBody;
+  try {
+    payload = (await request.json()) as RequestBody;
+  } catch {
+    return errorResponse(400, "VALIDATION_ERROR", "リクエストボディの形式が正しくありません。");
+  }
+
+  const method = (payload.method ?? "GET").toUpperCase();
+  if (!isHttpMethod(method)) {
+    return errorResponse(400, "VALIDATION_ERROR", "サポートされていないHTTPメソッドです。");
+  }
+
+  const validation = validateRequestUrl(payload.url ?? "");
+  if (!validation.ok) {
+    return errorResponse(400, validation.errorCode.toUpperCase(), validation.message);
+  }
+
+  const headers = sanitizeHeaders(payload.headers ?? {});
+  const body = methodAllowsBody(method) ? (payload.body ?? null) : null;
+
+  const start = performance.now();
+  let upstream: Response;
+  try {
+    upstream = await fetch(validation.url, {
+      method,
+      headers,
+      body,
+      redirect: "follow",
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+  } catch (e) {
+    const isTimeout = e instanceof Error && (e.name === "TimeoutError" || e.name === "AbortError");
+    return errorResponse(
+      isTimeout ? 504 : 502,
+      isTimeout ? "TIMEOUT" : "NETWORK_ERROR",
+      isTimeout
+        ? `リクエストが${TIMEOUT_MS / 1000}秒以内に完了しませんでした。`
+        : "リクエスト先に接続できませんでした。"
+    );
+  }
+
+  const { text, truncated } = await readBodyLimited(upstream);
+  const durationMs = Math.round(performance.now() - start);
+
+  return NextResponse.json({
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: headersToObject(upstream.headers),
+    body: text,
+    truncated,
+    durationMs,
+  });
+}
+
+function isHttpMethod(value: string): value is HttpMethod {
+  return (HTTP_METHODS as readonly string[]).includes(value);
+}
+
+function methodAllowsBody(method: HttpMethod): boolean {
+  return method !== "GET" && method !== "DELETE";
+}
+
+function sanitizeHeaders(headers: Record<string, string>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof key !== "string" || typeof value !== "string") continue;
+    const trimmedKey = key.trim();
+    if (!trimmedKey) continue;
+    if (FORBIDDEN_HEADERS.has(trimmedKey.toLowerCase())) continue;
+    result[trimmedKey] = value;
+  }
+  return result;
+}
+
+async function readBodyLimited(response: Response): Promise<{ text: string; truncated: boolean }> {
+  if (!response.body) {
+    return { text: "", truncated: false };
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  let truncated = false;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    if (received + value.byteLength > MAX_BODY_BYTES) {
+      const remaining = MAX_BODY_BYTES - received;
+      if (remaining > 0) {
+        chunks.push(value.slice(0, remaining));
+        received = MAX_BODY_BYTES;
+      }
+      truncated = true;
+      await reader.cancel().catch(() => {});
+      break;
+    }
+    chunks.push(value);
+    received += value.byteLength;
+  }
+
+  const merged = new Uint8Array(received);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  const text = new TextDecoder("utf-8", { fatal: false }).decode(merged);
+  return { text, truncated };
+}
+
+function headersToObject(headers: Headers): Record<string, string> {
+  const result: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    result[key] = value;
+  });
+  return result;
+}
+
+function errorResponse(status: number, errorCode: string, message: string): Response {
+  return NextResponse.json({ error: message, errorCode }, { status });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, ArrowLeftRight, Braces, Calculator, Clock, Cloud, Coins, FileText, Fingerprint, FileDiff, Github, Globe, Languages, Palette, Package, QrCode, Regex, Timer, Type, type LucideIcon } from "lucide-react";
+import { ArrowRight, ArrowLeftRight, Braces, Calculator, Clock, Cloud, Coins, FileText, Fingerprint, FileDiff, Github, Globe, Languages, Palette, Package, QrCode, Regex, Send, Timer, Type, type LucideIcon } from "lucide-react";
 import {
   Card,
   CardHeader,
@@ -151,6 +151,13 @@ const tools: Tool[] = [
     description: "自分のグローバルIPとジオロケーション、ISP・タイムゾーンなどを表示",
     href: "/tools/ip-info-viewer",
     icon: Globe,
+    category: "external-api",
+  },
+  {
+    name: "API Tester",
+    description: "REST API へリクエストを送信、レスポンスを整形表示・cURLエクスポート、セッション履歴",
+    href: "/tools/api-tester",
+    icon: Send,
     category: "external-api",
   },
 ];

--- a/src/app/tools/api-tester/page.tsx
+++ b/src/app/tools/api-tester/page.tsx
@@ -1,0 +1,5 @@
+import { ApiTesterPage } from "@/features/api-tester/components/api-tester-page";
+
+export default function Page() {
+  return <ApiTesterPage />;
+}

--- a/src/app/tools/api-tester/page.tsx
+++ b/src/app/tools/api-tester/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
 import { ApiTesterPage } from "@/features/api-tester/components/api-tester-page";
+
+export const metadata: Metadata = {
+  title: "API Tester - Personal Tools",
+  description:
+    "REST API へリクエストを送信、レスポンスを整形表示・cURLエクスポート、セッション履歴",
+};
 
 export default function Page() {
   return <ApiTesterPage />;

--- a/src/features/api-tester/components/api-tester-page.tsx
+++ b/src/features/api-tester/components/api-tester-page.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  ApiTesterError as ApiTesterClientError,
+  sendApiRequest,
+} from "../lib/api-tester-client";
+import { buildCurl } from "../lib/curl-builder";
+import { buildUrl, paramsFromUrl, toRecord } from "../lib/key-value-utils";
+import type {
+  ApiTesterError,
+  ApiTesterResponse,
+  HttpMethod,
+  KeyValue,
+  RequestRecord,
+} from "../lib/types";
+import { HistoryList } from "./history-list";
+import { RequestForm } from "./request-form";
+import { ResponseViewer } from "./response-viewer";
+
+const HISTORY_LIMIT = 50;
+
+export function ApiTesterPage() {
+  const [method, setMethod] = useState<HttpMethod>("GET");
+  const [urlBase, setUrlBase] = useState("");
+  const [params, setParams] = useState<KeyValue[]>([]);
+  const [headers, setHeaders] = useState<KeyValue[]>([]);
+  const [body, setBody] = useState("");
+  const [response, setResponse] = useState<ApiTesterResponse | undefined>();
+  const [error, setError] = useState<ApiTesterError | undefined>();
+  const [isLoading, setIsLoading] = useState(false);
+  const [history, setHistory] = useState<RequestRecord[]>([]);
+
+  const urlInput = useMemo(() => buildUrl(urlBase, params), [urlBase, params]);
+
+  const handleUrlInputChange = useCallback((next: string) => {
+    const parsed = paramsFromUrl(next);
+    if (!parsed) {
+      setUrlBase("");
+      setParams([]);
+      return;
+    }
+    setUrlBase(parsed.base);
+    setParams(parsed.params);
+  }, []);
+
+  const curlCommand = useMemo(() => {
+    if (!urlBase.trim()) return "";
+    return buildCurl({
+      method,
+      url: urlInput,
+      headers: toRecord(headers),
+      body: methodAllowsBody(method) && body ? body : null,
+    });
+  }, [method, urlInput, urlBase, headers, body]);
+
+  const handleSend = useCallback(async () => {
+    if (!urlInput.trim() || isLoading) return;
+    setIsLoading(true);
+    setResponse(undefined);
+    setError(undefined);
+
+    const recordBase = {
+      id: crypto.randomUUID(),
+      method,
+      url: urlInput,
+      params,
+      headers,
+      body,
+      timestamp: new Date(),
+    };
+
+    try {
+      const apiResponse = await sendApiRequest({
+        method,
+        url: urlInput,
+        headers: toRecord(headers),
+        body: methodAllowsBody(method) ? body : null,
+      });
+      setResponse(apiResponse);
+      setHistory((prev) =>
+        [{ ...recordBase, response: apiResponse }, ...prev].slice(0, HISTORY_LIMIT)
+      );
+    } catch (e) {
+      const errorPayload: ApiTesterError =
+        e instanceof ApiTesterClientError
+          ? { error: e.message, errorCode: e.errorCode }
+          : {
+              error: e instanceof Error ? e.message : "送信に失敗しました。",
+              errorCode: "UNKNOWN_ERROR",
+            };
+      setError(errorPayload);
+      setHistory((prev) =>
+        [{ ...recordBase, error: errorPayload }, ...prev].slice(0, HISTORY_LIMIT)
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [body, headers, isLoading, method, params, urlInput]);
+
+  const handleSelectHistory = useCallback((record: RequestRecord) => {
+    setMethod(record.method);
+    setParams(record.params);
+    setHeaders(record.headers);
+    setBody(record.body);
+    setResponse(record.response);
+    setError(record.error);
+    const queryless = record.url.includes("?")
+      ? record.url.slice(0, record.url.indexOf("?"))
+      : record.url;
+    setUrlBase(queryless);
+  }, []);
+
+  const handleClearHistory = useCallback(() => {
+    setHistory([]);
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">API Tester</h1>
+        <p className="mt-2 text-muted-foreground">
+          REST API へリクエストを送信し、レスポンスを整形表示・cURL 形式で出力できます。
+          リクエストはサーバー経由で送信されるため CORS の影響を受けません。
+        </p>
+      </div>
+
+      <RequestForm
+        method={method}
+        urlInput={urlInput}
+        params={params}
+        headers={headers}
+        body={body}
+        isLoading={isLoading}
+        curlCommand={curlCommand}
+        onMethodChange={setMethod}
+        onUrlInputChange={handleUrlInputChange}
+        onParamsChange={setParams}
+        onHeadersChange={setHeaders}
+        onBodyChange={setBody}
+        onSend={handleSend}
+      />
+
+      <ResponseViewer response={response} error={error} />
+
+      <section className="space-y-2">
+        <h2 className="text-lg font-semibold tracking-tight">履歴</h2>
+        <HistoryList
+          history={history}
+          onSelect={handleSelectHistory}
+          onClear={handleClearHistory}
+        />
+      </section>
+    </div>
+  );
+}
+
+function methodAllowsBody(method: HttpMethod): boolean {
+  return method !== "GET" && method !== "DELETE";
+}

--- a/src/features/api-tester/components/api-tester-page.tsx
+++ b/src/features/api-tester/components/api-tester-page.tsx
@@ -105,10 +105,8 @@ export function ApiTesterPage() {
     setBody(record.body);
     setResponse(record.response);
     setError(record.error);
-    const queryless = record.url.includes("?")
-      ? record.url.slice(0, record.url.indexOf("?"))
-      : record.url;
-    setUrlBase(queryless);
+    const parsed = paramsFromUrl(record.url);
+    setUrlBase(parsed?.base ?? record.url);
   }, []);
 
   const handleClearHistory = useCallback(() => {

--- a/src/features/api-tester/components/history-list.tsx
+++ b/src/features/api-tester/components/history-list.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { RequestRecord } from "../lib/types";
+
+type Props = {
+  history: RequestRecord[];
+  onSelect: (record: RequestRecord) => void;
+  onClear: () => void;
+};
+
+export function HistoryList({ history, onSelect, onClear }: Props) {
+  if (history.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        まだリクエストを送信していません。送信した内容がここに表示されます。
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          最新 {history.length} 件 (最大 50 件)
+        </p>
+        <Button variant="ghost" size="sm" onClick={onClear}>
+          <Trash2 className="size-4" />
+          クリア
+        </Button>
+      </div>
+      <ul className="divide-y rounded-md border">
+        {history.map((record) => {
+          const status = record.response?.status;
+          return (
+            <li key={record.id}>
+              <button
+                type="button"
+                onClick={() => onSelect(record)}
+                className="flex w-full items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-muted/50"
+              >
+                <Badge variant="outline" className="font-mono">
+                  {record.method}
+                </Badge>
+                <span className="flex-1 truncate font-mono text-sm">{record.url}</span>
+                {status !== undefined ? (
+                  <Badge variant={statusVariant(status)}>{status}</Badge>
+                ) : (
+                  <Badge variant="destructive">ERR</Badge>
+                )}
+                <span className="hidden text-xs text-muted-foreground sm:inline">
+                  {formatTime(record.timestamp)}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function statusVariant(status: number): "default" | "secondary" | "destructive" | "outline" {
+  if (status >= 200 && status < 300) return "default";
+  if (status >= 300 && status < 400) return "secondary";
+  return "destructive";
+}
+
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString("ja-JP", { hour12: false });
+}

--- a/src/features/api-tester/components/key-value-editor.tsx
+++ b/src/features/api-tester/components/key-value-editor.tsx
@@ -40,39 +40,42 @@ export function KeyValueEditor({
         <p className="text-sm text-muted-foreground">{emptyLabel}</p>
       ) : (
         <div className="space-y-2">
-          {rows.map((row) => (
-            <div key={row.id} className="flex items-center gap-2">
-              <Switch
-                size="sm"
-                checked={row.enabled}
-                onCheckedChange={(enabled) => updateRow(row.id, { enabled })}
-                aria-label="この項目を有効にする"
-              />
-              <Input
-                value={row.key}
-                onChange={(e) => updateRow(row.id, { key: e.target.value })}
-                placeholder={keyPlaceholder}
-                className="flex-1 font-mono"
-                aria-label="key"
-              />
-              <Input
-                value={row.value}
-                onChange={(e) => updateRow(row.id, { value: e.target.value })}
-                placeholder={valuePlaceholder}
-                className="flex-1 font-mono"
-                aria-label="value"
-              />
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                onClick={() => removeRow(row.id)}
-                aria-label="この行を削除"
-              >
-                <Trash2 className="size-4" />
-              </Button>
-            </div>
-          ))}
+          {rows.map((row, index) => {
+            const rowNumber = index + 1;
+            return (
+              <div key={row.id} className="flex items-center gap-2">
+                <Switch
+                  size="sm"
+                  checked={row.enabled}
+                  onCheckedChange={(enabled) => updateRow(row.id, { enabled })}
+                  aria-label={`${rowNumber}行目を有効にする`}
+                />
+                <Input
+                  value={row.key}
+                  onChange={(e) => updateRow(row.id, { key: e.target.value })}
+                  placeholder={keyPlaceholder}
+                  className="flex-1 font-mono"
+                  aria-label={`${rowNumber}行目 ${keyPlaceholder}`}
+                />
+                <Input
+                  value={row.value}
+                  onChange={(e) => updateRow(row.id, { value: e.target.value })}
+                  placeholder={valuePlaceholder}
+                  className="flex-1 font-mono"
+                  aria-label={`${rowNumber}行目 ${valuePlaceholder}`}
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => removeRow(row.id)}
+                  aria-label={`${rowNumber}行目を削除`}
+                >
+                  <Trash2 className="size-4" />
+                </Button>
+              </div>
+            );
+          })}
         </div>
       )}
       <Button type="button" variant="outline" size="sm" onClick={addRow}>

--- a/src/features/api-tester/components/key-value-editor.tsx
+++ b/src/features/api-tester/components/key-value-editor.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import type { KeyValue } from "../lib/types";
+import { createEmptyRow } from "../lib/key-value-utils";
+
+type Props = {
+  rows: KeyValue[];
+  onChange: (rows: KeyValue[]) => void;
+  keyPlaceholder?: string;
+  valuePlaceholder?: string;
+  emptyLabel?: string;
+};
+
+export function KeyValueEditor({
+  rows,
+  onChange,
+  keyPlaceholder = "key",
+  valuePlaceholder = "value",
+  emptyLabel = "まだ項目がありません。",
+}: Props) {
+  const updateRow = (id: string, patch: Partial<KeyValue>) => {
+    onChange(rows.map((row) => (row.id === id ? { ...row, ...patch } : row)));
+  };
+
+  const removeRow = (id: string) => {
+    onChange(rows.filter((row) => row.id !== id));
+  };
+
+  const addRow = () => {
+    onChange([...rows, createEmptyRow()]);
+  };
+
+  return (
+    <div className="space-y-2">
+      {rows.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{emptyLabel}</p>
+      ) : (
+        <div className="space-y-2">
+          {rows.map((row) => (
+            <div key={row.id} className="flex items-center gap-2">
+              <Switch
+                size="sm"
+                checked={row.enabled}
+                onCheckedChange={(enabled) => updateRow(row.id, { enabled })}
+                aria-label="この項目を有効にする"
+              />
+              <Input
+                value={row.key}
+                onChange={(e) => updateRow(row.id, { key: e.target.value })}
+                placeholder={keyPlaceholder}
+                className="flex-1 font-mono"
+                aria-label="key"
+              />
+              <Input
+                value={row.value}
+                onChange={(e) => updateRow(row.id, { value: e.target.value })}
+                placeholder={valuePlaceholder}
+                className="flex-1 font-mono"
+                aria-label="value"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => removeRow(row.id)}
+                aria-label="この行を削除"
+              >
+                <Trash2 className="size-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+      <Button type="button" variant="outline" size="sm" onClick={addRow}>
+        <Plus className="size-4" />
+        行を追加
+      </Button>
+    </div>
+  );
+}

--- a/src/features/api-tester/components/request-form.tsx
+++ b/src/features/api-tester/components/request-form.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { Send, Terminal, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import { useClipboard } from "@/lib/use-clipboard";
+import type { HttpMethod, KeyValue } from "../lib/types";
+import { HTTP_METHODS } from "../lib/types";
+import { KeyValueEditor } from "./key-value-editor";
+
+type Props = {
+  method: HttpMethod;
+  urlInput: string;
+  params: KeyValue[];
+  headers: KeyValue[];
+  body: string;
+  isLoading: boolean;
+  curlCommand: string;
+  onMethodChange: (method: HttpMethod) => void;
+  onUrlInputChange: (url: string) => void;
+  onParamsChange: (params: KeyValue[]) => void;
+  onHeadersChange: (headers: KeyValue[]) => void;
+  onBodyChange: (body: string) => void;
+  onSend: () => void;
+};
+
+export function RequestForm({
+  method,
+  urlInput,
+  params,
+  headers,
+  body,
+  isLoading,
+  curlCommand,
+  onMethodChange,
+  onUrlInputChange,
+  onParamsChange,
+  onHeadersChange,
+  onBodyChange,
+  onSend,
+}: Props) {
+  const { copy, isCopied } = useClipboard();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSend();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <Select value={method} onValueChange={(v) => onMethodChange(v as HttpMethod)}>
+          <SelectTrigger className="w-full sm:w-32" aria-label="HTTPメソッド">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {HTTP_METHODS.map((m) => (
+              <SelectItem key={m} value={m}>
+                {m}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Input
+          value={urlInput}
+          onChange={(e) => onUrlInputChange(e.target.value)}
+          placeholder="https://api.example.com/path"
+          className="flex-1 font-mono"
+          aria-label="URL"
+        />
+        <Button type="submit" disabled={isLoading} className="sm:w-28">
+          <Send className="size-4" />
+          {isLoading ? "送信中…" : "送信"}
+        </Button>
+      </div>
+
+      <Tabs defaultValue="params">
+        <TabsList>
+          <TabsTrigger value="params">
+            Params{params.filter((p) => p.enabled && p.key.trim()).length > 0
+              ? ` (${params.filter((p) => p.enabled && p.key.trim()).length})`
+              : ""}
+          </TabsTrigger>
+          <TabsTrigger value="headers">
+            Headers{headers.filter((h) => h.enabled && h.key.trim()).length > 0
+              ? ` (${headers.filter((h) => h.enabled && h.key.trim()).length})`
+              : ""}
+          </TabsTrigger>
+          <TabsTrigger value="body">Body</TabsTrigger>
+        </TabsList>
+        <TabsContent value="params" className="pt-2">
+          <KeyValueEditor
+            rows={params}
+            onChange={onParamsChange}
+            keyPlaceholder="param"
+            valuePlaceholder="value"
+            emptyLabel="クエリパラメータはありません。"
+          />
+        </TabsContent>
+        <TabsContent value="headers" className="pt-2">
+          <KeyValueEditor
+            rows={headers}
+            onChange={onHeadersChange}
+            keyPlaceholder="Header-Name"
+            valuePlaceholder="value"
+            emptyLabel="ヘッダーはありません。"
+          />
+        </TabsContent>
+        <TabsContent value="body" className="pt-2">
+          <Textarea
+            value={body}
+            onChange={(e) => onBodyChange(e.target.value)}
+            placeholder='{"key": "value"}'
+            className="min-h-32 font-mono text-sm"
+            aria-label="リクエストボディ"
+          />
+          <p className="mt-2 text-xs text-muted-foreground">
+            GET / DELETE では送信されません。Content-Type は Headers タブで指定してください。
+          </p>
+        </TabsContent>
+      </Tabs>
+
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => copy(curlCommand)}
+          disabled={!curlCommand}
+        >
+          {isCopied ? <Check className="size-4" /> : <Terminal className="size-4" />}
+          {isCopied ? "コピーしました" : "cURLをコピー"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/features/api-tester/components/response-viewer.tsx
+++ b/src/features/api-tester/components/response-viewer.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { Check, Clock, Copy } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import { useClipboard } from "@/lib/use-clipboard";
+import type { ApiTesterError, ApiTesterResponse } from "../lib/types";
+import { tryFormatJson } from "../lib/api-tester-client";
+
+type Props = {
+  response?: ApiTesterResponse;
+  error?: ApiTesterError;
+};
+
+export function ResponseViewer({ response, error }: Props) {
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>リクエスト失敗 ({error.errorCode})</AlertTitle>
+        <AlertDescription>{error.error}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!response) return null;
+
+  const formattedBody = tryFormatJson(response.body);
+  const headerEntries = Object.entries(response.headers);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant={statusVariant(response.status)}>
+          {response.status} {response.statusText}
+        </Badge>
+        <Badge variant="outline" className="gap-1">
+          <Clock className="size-3" aria-hidden="true" />
+          {response.durationMs} ms
+        </Badge>
+        <Badge variant="outline">{formatBytes(byteLengthOf(response.body))}</Badge>
+        {response.truncated ? (
+          <Badge variant="destructive">本文を 1MB で切り詰めました</Badge>
+        ) : null}
+      </div>
+
+      <Tabs defaultValue="body">
+        <TabsList>
+          <TabsTrigger value="body">Body</TabsTrigger>
+          <TabsTrigger value="headers">Headers ({headerEntries.length})</TabsTrigger>
+        </TabsList>
+        <TabsContent value="body" className="pt-2">
+          <BodyPanel value={formattedBody} />
+        </TabsContent>
+        <TabsContent value="headers" className="pt-2">
+          {headerEntries.length === 0 ? (
+            <p className="text-sm text-muted-foreground">ヘッダーはありません。</p>
+          ) : (
+            <div className="overflow-auto rounded-md border">
+              <table className="w-full text-sm">
+                <tbody>
+                  {headerEntries.map(([name, value]) => (
+                    <tr key={name} className="border-b last:border-b-0">
+                      <td className="px-3 py-2 align-top font-mono text-xs font-medium">
+                        {name}
+                      </td>
+                      <td className="px-3 py-2 align-top font-mono text-xs break-all">
+                        {value}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function BodyPanel({ value }: { value: string }) {
+  const { copy, isCopied } = useClipboard();
+  if (!value) {
+    return <p className="text-sm text-muted-foreground">レスポンス本文はありません。</p>;
+  }
+  return (
+    <div className="relative">
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        className="absolute top-2 right-2"
+        onClick={() => copy(value)}
+        aria-label="レスポンス本文をコピー"
+      >
+        {isCopied ? <Check className="size-3" /> : <Copy className="size-3" />}
+      </Button>
+      <pre className="max-h-[480px] overflow-auto rounded-md border bg-muted/50 p-4 text-sm font-mono">
+        {value}
+      </pre>
+    </div>
+  );
+}
+
+function statusVariant(status: number): "default" | "secondary" | "destructive" | "outline" {
+  if (status >= 200 && status < 300) return "default";
+  if (status >= 300 && status < 400) return "secondary";
+  return "destructive";
+}
+
+function byteLengthOf(text: string): number {
+  if (typeof TextEncoder === "undefined") return text.length;
+  return new TextEncoder().encode(text).byteLength;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}

--- a/src/features/api-tester/lib/__tests__/curl-builder.test.ts
+++ b/src/features/api-tester/lib/__tests__/curl-builder.test.ts
@@ -1,0 +1,64 @@
+import { buildCurl } from "../curl-builder";
+
+describe("buildCurl", () => {
+  it("builds GET curl without body", () => {
+    const result = buildCurl({
+      method: "GET",
+      url: "https://api.example.com/users",
+      headers: {},
+      body: null,
+    });
+    expect(result).toBe("curl -X GET \\\n  'https://api.example.com/users'");
+  });
+
+  it("includes headers", () => {
+    const result = buildCurl({
+      method: "GET",
+      url: "https://api.example.com",
+      headers: { Accept: "application/json", "X-Token": "abc" },
+      body: null,
+    });
+    expect(result).toContain("-H 'Accept: application/json'");
+    expect(result).toContain("-H 'X-Token: abc'");
+  });
+
+  it("includes body for POST", () => {
+    const result = buildCurl({
+      method: "POST",
+      url: "https://api.example.com/posts",
+      headers: { "Content-Type": "application/json" },
+      body: '{"title":"hello"}',
+    });
+    expect(result).toContain("--data '{\"title\":\"hello\"}'");
+  });
+
+  it("escapes single quotes in values", () => {
+    const result = buildCurl({
+      method: "POST",
+      url: "https://api.example.com",
+      headers: { "X-Note": "it's fine" },
+      body: "name='alice'",
+    });
+    expect(result).toContain("'X-Note: it'\\''s fine'");
+    expect(result).toContain("'name='\\''alice'\\'''");
+  });
+
+  it("omits body when null or empty", () => {
+    expect(
+      buildCurl({
+        method: "POST",
+        url: "https://x.test",
+        headers: {},
+        body: null,
+      })
+    ).not.toContain("--data");
+    expect(
+      buildCurl({
+        method: "POST",
+        url: "https://x.test",
+        headers: {},
+        body: "",
+      })
+    ).not.toContain("--data");
+  });
+});

--- a/src/features/api-tester/lib/__tests__/key-value-utils.test.ts
+++ b/src/features/api-tester/lib/__tests__/key-value-utils.test.ts
@@ -1,0 +1,96 @@
+import {
+  buildUrl,
+  paramsFromUrl,
+  paramsToQueryString,
+  toRecord,
+} from "../key-value-utils";
+import type { KeyValue } from "../types";
+
+const row = (overrides: Partial<KeyValue> = {}): KeyValue => ({
+  id: overrides.id ?? Math.random().toString(36),
+  enabled: overrides.enabled ?? true,
+  key: overrides.key ?? "",
+  value: overrides.value ?? "",
+});
+
+describe("toRecord", () => {
+  it("includes only enabled rows with non-empty trimmed key", () => {
+    const result = toRecord([
+      row({ key: "a", value: "1" }),
+      row({ key: "b", value: "2", enabled: false }),
+      row({ key: "  ", value: "3" }),
+      row({ key: "  c  ", value: "4" }),
+    ]);
+    expect(result).toEqual({ a: "1", c: "4" });
+  });
+
+  it("later enabled rows override earlier ones for the same key", () => {
+    const result = toRecord([
+      row({ key: "x", value: "1" }),
+      row({ key: "x", value: "2" }),
+    ]);
+    expect(result).toEqual({ x: "2" });
+  });
+});
+
+describe("paramsToQueryString", () => {
+  it("returns empty string when no enabled rows", () => {
+    expect(paramsToQueryString([])).toBe("");
+    expect(paramsToQueryString([row({ key: "a", value: "1", enabled: false })])).toBe("");
+  });
+
+  it("encodes values and preserves order", () => {
+    const result = paramsToQueryString([
+      row({ key: "q", value: "hello world" }),
+      row({ key: "tag", value: "a&b" }),
+    ]);
+    expect(result).toBe("?q=hello+world&tag=a%26b");
+  });
+});
+
+describe("paramsFromUrl", () => {
+  it("returns base and empty params when no query string", () => {
+    const result = paramsFromUrl("https://example.com/path");
+    expect(result?.base).toBe("https://example.com/path");
+    expect(result?.params).toEqual([]);
+  });
+
+  it("splits query string into key-value rows", () => {
+    const result = paramsFromUrl("https://example.com?a=1&b=hello+world");
+    expect(result?.base).toBe("https://example.com");
+    expect(result?.params.map(({ key, value, enabled }) => ({ key, value, enabled }))).toEqual([
+      { key: "a", value: "1", enabled: true },
+      { key: "b", value: "hello world", enabled: true },
+    ]);
+  });
+
+  it("preserves hash fragment in base", () => {
+    const result = paramsFromUrl("https://example.com/path?a=1#section");
+    expect(result?.base).toBe("https://example.com/path#section");
+  });
+
+  it("returns null for empty input", () => {
+    expect(paramsFromUrl("")).toBeNull();
+    expect(paramsFromUrl("   ")).toBeNull();
+  });
+});
+
+describe("buildUrl", () => {
+  it("removes existing query string before appending params", () => {
+    const result = buildUrl("https://example.com?old=1", [row({ key: "new", value: "2" })]);
+    expect(result).toBe("https://example.com?new=2");
+  });
+
+  it("preserves hash fragment", () => {
+    const result = buildUrl("https://example.com/path#frag", [row({ key: "a", value: "1" })]);
+    expect(result).toBe("https://example.com/path?a=1#frag");
+  });
+
+  it("returns base unchanged when no enabled rows", () => {
+    expect(buildUrl("https://example.com", [])).toBe("https://example.com");
+  });
+
+  it("returns empty string when base is empty", () => {
+    expect(buildUrl("", [row({ key: "a", value: "1" })])).toBe("");
+  });
+});

--- a/src/features/api-tester/lib/__tests__/url-validator.test.ts
+++ b/src/features/api-tester/lib/__tests__/url-validator.test.ts
@@ -1,0 +1,106 @@
+import { validateRequestUrl } from "../url-validator";
+
+describe("validateRequestUrl", () => {
+  it("accepts https URL", () => {
+    const result = validateRequestUrl("https://api.example.com/path");
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts http URL", () => {
+    const result = validateRequestUrl("http://api.example.com/path");
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects empty input", () => {
+    const result = validateRequestUrl("");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errorCode).toBe("invalid_url");
+  });
+
+  it("rejects whitespace-only input", () => {
+    const result = validateRequestUrl("   ");
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects malformed URL", () => {
+    const result = validateRequestUrl("not a url");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.errorCode).toBe("invalid_url");
+  });
+
+  it("rejects non-http(s) protocols", () => {
+    for (const url of [
+      "ftp://example.com",
+      "file:///etc/passwd",
+      "javascript:alert(1)",
+    ]) {
+      const result = validateRequestUrl(url);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.errorCode).toBe("invalid_url");
+    }
+  });
+
+  it("blocks localhost variants", () => {
+    for (const url of [
+      "http://localhost",
+      "http://localhost:8080/api",
+      "http://api.localhost",
+      "http://LOCALHOST",
+    ]) {
+      const result = validateRequestUrl(url);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.errorCode).toBe("blocked_url");
+    }
+  });
+
+  it("blocks loopback IPv4", () => {
+    for (const url of ["http://127.0.0.1", "http://127.5.5.5:8080"]) {
+      const result = validateRequestUrl(url);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.errorCode).toBe("blocked_url");
+    }
+  });
+
+  it("blocks private IPv4 ranges", () => {
+    for (const url of [
+      "http://10.0.0.1",
+      "http://10.255.255.255",
+      "http://172.16.0.1",
+      "http://172.31.255.255",
+      "http://192.168.1.1",
+      "http://169.254.169.254",
+      "http://0.0.0.0",
+    ]) {
+      const result = validateRequestUrl(url);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.errorCode).toBe("blocked_url");
+    }
+  });
+
+  it("allows public IPv4", () => {
+    for (const url of ["http://8.8.8.8", "http://172.15.0.1", "http://172.32.0.1"]) {
+      const result = validateRequestUrl(url);
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  it("blocks IPv6 loopback and private ranges", () => {
+    for (const url of [
+      "http://[::1]",
+      "http://[::]",
+      "http://[fe80::1]",
+      "http://[fc00::1]",
+      "http://[fd00::1]",
+      "http://[::ffff:127.0.0.1]",
+    ]) {
+      const result = validateRequestUrl(url);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.errorCode).toBe("blocked_url");
+    }
+  });
+
+  it("blocks IPv4 multicast (224.0.0.0+)", () => {
+    const result = validateRequestUrl("http://224.0.0.1");
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/features/api-tester/lib/api-tester-client.ts
+++ b/src/features/api-tester/lib/api-tester-client.ts
@@ -1,0 +1,50 @@
+import type { ApiTesterRequest, ApiTesterResponse } from "./types";
+
+export class ApiTesterError extends Error {
+  readonly errorCode: string;
+
+  constructor(message: string, errorCode: string) {
+    super(message);
+    this.name = "ApiTesterError";
+    this.errorCode = errorCode;
+  }
+}
+
+export async function sendApiRequest(request: ApiTesterRequest): Promise<ApiTesterResponse> {
+  let response: Response;
+  try {
+    response = await fetch("/api/api-tester", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    });
+  } catch {
+    throw new ApiTesterError("プロキシサーバーに接続できませんでした。", "CLIENT_NETWORK_ERROR");
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new ApiTesterError(`リクエストに失敗しました。（${response.status}）`, "INVALID_RESPONSE");
+  }
+
+  if (!response.ok) {
+    const errorPayload = payload as { error?: string; errorCode?: string };
+    throw new ApiTesterError(
+      errorPayload.error ?? `リクエストに失敗しました。（${response.status}）`,
+      errorPayload.errorCode ?? "UNKNOWN_ERROR"
+    );
+  }
+
+  return payload as ApiTesterResponse;
+}
+
+export function tryFormatJson(text: string): string {
+  if (!text) return "";
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return text;
+  }
+}

--- a/src/features/api-tester/lib/curl-builder.ts
+++ b/src/features/api-tester/lib/curl-builder.ts
@@ -1,0 +1,19 @@
+import type { ApiTesterRequest } from "./types";
+
+export function buildCurl(request: ApiTesterRequest): string {
+  const parts = [`curl -X ${request.method}`, shellQuote(request.url)];
+
+  for (const [key, value] of Object.entries(request.headers)) {
+    parts.push(`-H ${shellQuote(`${key}: ${value}`)}`);
+  }
+
+  if (request.body !== null && request.body !== "") {
+    parts.push(`--data ${shellQuote(request.body)}`);
+  }
+
+  return parts.join(" \\\n  ");
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/src/features/api-tester/lib/key-value-utils.ts
+++ b/src/features/api-tester/lib/key-value-utils.ts
@@ -1,0 +1,73 @@
+import type { KeyValue } from "./types";
+
+export function createEmptyRow(): KeyValue {
+  return {
+    id: crypto.randomUUID(),
+    enabled: true,
+    key: "",
+    value: "",
+  };
+}
+
+export function toRecord(rows: KeyValue[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const row of rows) {
+    if (!row.enabled) continue;
+    const key = row.key.trim();
+    if (!key) continue;
+    result[key] = row.value;
+  }
+  return result;
+}
+
+export function paramsToQueryString(rows: KeyValue[]): string {
+  const params = new URLSearchParams();
+  for (const row of rows) {
+    if (!row.enabled) continue;
+    const key = row.key.trim();
+    if (!key) continue;
+    params.append(key, row.value);
+  }
+  const serialized = params.toString();
+  return serialized ? `?${serialized}` : "";
+}
+
+export function paramsFromUrl(url: string): { base: string; params: KeyValue[] } | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+
+  const queryStart = trimmed.indexOf("?");
+  if (queryStart === -1) {
+    return { base: trimmed, params: [] };
+  }
+
+  const base = trimmed.slice(0, queryStart);
+  const queryAndHash = trimmed.slice(queryStart + 1);
+  const hashStart = queryAndHash.indexOf("#");
+  const queryString = hashStart === -1 ? queryAndHash : queryAndHash.slice(0, hashStart);
+  const hash = hashStart === -1 ? "" : queryAndHash.slice(hashStart);
+
+  const search = new URLSearchParams(queryString);
+  const params: KeyValue[] = [];
+  for (const [key, value] of search.entries()) {
+    params.push({
+      id: crypto.randomUUID(),
+      enabled: true,
+      key,
+      value,
+    });
+  }
+  return { base: base + hash, params };
+}
+
+export function buildUrl(base: string, params: KeyValue[]): string {
+  if (!base) return "";
+  const trimmed = base.trim();
+  const hashStart = trimmed.indexOf("#");
+  const beforeHash = hashStart === -1 ? trimmed : trimmed.slice(0, hashStart);
+  const hash = hashStart === -1 ? "" : trimmed.slice(hashStart);
+  const queryStart = beforeHash.indexOf("?");
+  const baseWithoutQuery = queryStart === -1 ? beforeHash : beforeHash.slice(0, queryStart);
+  const query = paramsToQueryString(params);
+  return `${baseWithoutQuery}${query}${hash}`;
+}

--- a/src/features/api-tester/lib/types.ts
+++ b/src/features/api-tester/lib/types.ts
@@ -1,0 +1,43 @@
+export const HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"] as const;
+
+export type HttpMethod = (typeof HTTP_METHODS)[number];
+
+export type KeyValue = {
+  id: string;
+  enabled: boolean;
+  key: string;
+  value: string;
+};
+
+export type ApiTesterRequest = {
+  method: HttpMethod;
+  url: string;
+  headers: Record<string, string>;
+  body: string | null;
+};
+
+export type ApiTesterResponse = {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: string;
+  truncated: boolean;
+  durationMs: number;
+};
+
+export type ApiTesterError = {
+  error: string;
+  errorCode: string;
+};
+
+export type RequestRecord = {
+  id: string;
+  method: HttpMethod;
+  url: string;
+  params: KeyValue[];
+  headers: KeyValue[];
+  body: string;
+  response?: ApiTesterResponse;
+  error?: ApiTesterError;
+  timestamp: Date;
+};

--- a/src/features/api-tester/lib/url-validator.ts
+++ b/src/features/api-tester/lib/url-validator.ts
@@ -1,0 +1,90 @@
+export type UrlValidation =
+  | { ok: true; url: URL }
+  | { ok: false; errorCode: "invalid_url" | "blocked_url"; message: string };
+
+const IPV4_PATTERN = /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d?\d)$/;
+
+export function validateRequestUrl(input: string): UrlValidation {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return {
+      ok: false,
+      errorCode: "invalid_url",
+      message: "URLを入力してください。",
+    };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return {
+      ok: false,
+      errorCode: "invalid_url",
+      message: "URLの形式が正しくありません。",
+    };
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return {
+      ok: false,
+      errorCode: "invalid_url",
+      message: "http または https のURLのみ送信できます。",
+    };
+  }
+
+  const hostname = normalizeHostname(url.hostname);
+  if (isBlockedHost(hostname)) {
+    return {
+      ok: false,
+      errorCode: "blocked_url",
+      message: "ローカル/プライベートネットワークへのリクエストは送信できません。",
+    };
+  }
+
+  return { ok: true, url };
+}
+
+function normalizeHostname(host: string): string {
+  if (host.startsWith("[") && host.endsWith("]")) {
+    return host.slice(1, -1).toLowerCase();
+  }
+  return host.toLowerCase();
+}
+
+function isBlockedHost(host: string): boolean {
+  if (!host) return true;
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+
+  if (IPV4_PATTERN.test(host)) {
+    return isBlockedIpv4(host);
+  }
+
+  if (host.includes(":")) {
+    return isBlockedIpv6(host);
+  }
+
+  return false;
+}
+
+function isBlockedIpv4(host: string): boolean {
+  const [a, b] = host.split(".").map((n) => Number.parseInt(n, 10));
+  if (a === 0) return true;
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a >= 224) return true;
+  return false;
+}
+
+function isBlockedIpv6(host: string): boolean {
+  if (host === "::" || host === "::1") return true;
+  if (host.startsWith("fe80:") || host.startsWith("fe80::")) return true;
+  const head = host.slice(0, 2);
+  if (head === "fc" || head === "fd") return true;
+  // IPv4-mapped IPv6 (::ffff:*) — block all forms regardless of mapped value
+  if (host.startsWith("::ffff:")) return true;
+  return false;
+}


### PR DESCRIPTION
## Summary
- REST API へのリクエスト送信・レスポンス整形表示・cURL エクスポート・セッション履歴 (最大50件) を備えた API テスターツール (`/tools/api-tester`) を追加
- 送信は `/api/api-tester` のサーバーサイドプロキシ経由とし CORS を回避。SSRF 対策 (`localhost` / プライベート IPv4 / loopback / link-local / multicast / IPv4-mapped IPv6 をブロック)、レート制限 (30req/min/IP)、15s タイムアウト、レスポンス本文 1MB 上限を適用
- GET / POST / PUT / DELETE / PATCH に対応 (Issue 記載の GET/POST から拡張)
- `curl-builder` / `key-value-utils` / `url-validator` の純粋ロジックには 29 件のユニットテストを追加

> ⚠️ ファイル数 16 / 変更行数 +1313 と PR サイズ上限 (10 ファイル / 300 行) を超過していますが、新機能追加で大半が新規ファイル作成のため、shared-claude-code の例外規定に該当します。

Closes #38

## Test plan
- [x] `npm run lint` 通過
- [x] `npm run test` 通過 (587/587、新規 29 件含む)
- [x] `npm run build` 通過 (`/api/api-tester` `/tools/api-tester` がルート登録)
- [x] `curl` で `/api/api-tester` のスモークテスト (GET/POST/DELETE 成功、`localhost` / `192.168.x` / `file://` / 不正 URL / 非対応メソッドが想定通りエラーコードを返すこと)
- [ ] ブラウザで `/tools/api-tester` を開き UI 動作確認: Tabs (Params/Headers/Body) 切替、KeyValueEditor の追加/削除/有効スイッチ、URL ↔ Params の双方向同期、履歴クリックによる復元、cURL クリップボードコピー
- [ ] レスポンス JSON が整形表示・ステータスバッジ色分け (2xx default / 3xx secondary / 4xx-5xx destructive)・所要時間バッジが正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)