### PR TITLE
feat: リンク切れチェッカーを追加

### DIFF
--- a/src/app/api/broken-link-checker/route.ts
+++ b/src/app/api/broken-link-checker/route.ts
@@ -1,0 +1,300 @@
+import { NextResponse } from "next/server";
+import { chromium, type APIRequestContext, type Browser, type BrowserContext } from "playwright";
+import { createRateLimit } from "@/lib/rate-limit";
+import { getClientIp, rateLimitResponse } from "@/lib/api-helpers";
+import { validateRequestUrl } from "@/lib/url-validator";
+import {
+  LINK_REQUEST_TIMEOUT_MS,
+  MAX_LINKS_TO_CHECK,
+  NAVIGATION_TIMEOUT_MS,
+  REQUEST_CONCURRENCY,
+  classifyStatus,
+  isDepth,
+  type CheckerResponse,
+  type Depth,
+  type LinkResult,
+} from "@/features/broken-link-checker/lib/types";
+
+export const runtime = "nodejs";
+
+const rateLimit = createRateLimit({ limit: 5, windowMs: 60_000 });
+
+// Max number of internal pages to crawl when depth=2 (1 entry page + N internal pages).
+const MAX_INTERNAL_CRAWL_PAGES = 5;
+
+const USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36";
+
+type RequestBody = {
+  url?: unknown;
+  depth?: unknown;
+};
+
+type DiscoveredLink = {
+  url: string;
+  isInternal: boolean;
+  sourcePage: string;
+};
+
+export async function POST(request: Request) {
+  const ip = getClientIp(request);
+  if (ip !== "unknown") {
+    const result = rateLimit.check(ip);
+    if (!result.allowed) {
+      return rateLimitResponse(result.retryAfterMs);
+    }
+  }
+
+  let payload: RequestBody;
+  try {
+    payload = (await request.json()) as RequestBody;
+  } catch {
+    return errorResponse(400, "VALIDATION_ERROR", "リクエストボディの形式が正しくありません。");
+  }
+
+  const validation = validateRequestUrl(typeof payload.url === "string" ? payload.url : "");
+  if (!validation.ok) {
+    return errorResponse(400, validation.errorCode.toUpperCase(), validation.message);
+  }
+
+  if (!isDepth(payload.depth)) {
+    return errorResponse(400, "VALIDATION_ERROR", "階層は 1 または 2 を指定してください。");
+  }
+  const depth: Depth = payload.depth;
+
+  const targetUrl = validation.url.toString();
+  const targetHost = validation.url.hostname.toLowerCase();
+  const start = performance.now();
+
+  let browser: Browser;
+  try {
+    browser = await chromium.launch();
+  } catch (e) {
+    console.error("[broken-link-checker] failed to launch chromium", e);
+    return errorResponse(
+      500,
+      "BROWSER_LAUNCH_FAILED",
+      "ブラウザの起動に失敗しました。Playwrightのインストール状態を確認してください。",
+    );
+  }
+
+  let context: BrowserContext | undefined;
+  try {
+    context = await browser.newContext({ userAgent: USER_AGENT });
+
+    const discovery = await discoverLinks(context, targetUrl, targetHost, depth);
+    if ("error" in discovery) {
+      return errorResponse(discovery.error.status, discovery.error.code, discovery.error.message);
+    }
+
+    const totalFound = discovery.links.length;
+    const truncated = totalFound > MAX_LINKS_TO_CHECK;
+    const toCheck = truncated ? discovery.links.slice(0, MAX_LINKS_TO_CHECK) : discovery.links;
+
+    const checked = await checkLinks(context.request, toCheck);
+
+    const response: CheckerResponse = {
+      url: targetUrl,
+      depth,
+      links: checked,
+      totalFound,
+      totalChecked: checked.length,
+      truncated,
+      durationMs: Math.round(performance.now() - start),
+    };
+    return NextResponse.json(response);
+  } catch (e) {
+    const isTimeout = e instanceof Error && (e.name === "TimeoutError" || /timeout/i.test(e.message));
+    return errorResponse(
+      isTimeout ? 504 : 502,
+      isTimeout ? "TIMEOUT" : "CRAWL_FAILED",
+      isTimeout
+        ? `ページ読み込みが${NAVIGATION_TIMEOUT_MS / 1000}秒以内に完了しませんでした。`
+        : "リンクのクロールに失敗しました。",
+    );
+  } finally {
+    if (context) await context.close().catch(() => {});
+    await browser.close().catch(() => {});
+  }
+}
+
+type DiscoveryResult =
+  | { links: DiscoveredLink[] }
+  | { error: { status: number; code: string; message: string } };
+
+async function discoverLinks(
+  context: BrowserContext,
+  entryUrl: string,
+  entryHost: string,
+  depth: Depth,
+): Promise<DiscoveryResult> {
+  const seen = new Map<string, DiscoveredLink>();
+  const visitedPages = new Set<string>();
+
+  try {
+    await crawlPage(context, entryUrl, entryHost, seen, visitedPages);
+  } catch (e) {
+    const isTimeout = e instanceof Error && (e.name === "TimeoutError" || /timeout/i.test(e.message));
+    return {
+      error: {
+        status: isTimeout ? 504 : 502,
+        code: isTimeout ? "TIMEOUT" : "CRAWL_FAILED",
+        message: isTimeout
+          ? `ページ読み込みが${NAVIGATION_TIMEOUT_MS / 1000}秒以内に完了しませんでした。`
+          : "ページの読み込みに失敗しました。",
+      },
+    };
+  }
+
+  if (depth === 2) {
+    const internalLinks = [...seen.values()].filter(
+      (l) => l.isInternal && !visitedPages.has(l.url),
+    );
+    for (const link of internalLinks.slice(0, MAX_INTERNAL_CRAWL_PAGES)) {
+      if (seen.size >= MAX_LINKS_TO_CHECK) break;
+      try {
+        await crawlPage(context, link.url, entryHost, seen, visitedPages);
+      } catch {
+        // Internal page failed to load — skip; the link itself will still be checked.
+      }
+    }
+  }
+
+  return { links: [...seen.values()] };
+}
+
+async function crawlPage(
+  context: BrowserContext,
+  pageUrl: string,
+  entryHost: string,
+  seen: Map<string, DiscoveredLink>,
+  visitedPages: Set<string>,
+): Promise<void> {
+  if (visitedPages.has(pageUrl)) return;
+  visitedPages.add(pageUrl);
+
+  const page = await context.newPage();
+  try {
+    await page.goto(pageUrl, { waitUntil: "load", timeout: NAVIGATION_TIMEOUT_MS });
+    const hrefs = (await page.evaluate(() => {
+      const anchors = Array.from(document.querySelectorAll<HTMLAnchorElement>("a[href]"));
+      return anchors.map((a) => a.href);
+    })) as string[];
+
+    for (const href of hrefs) {
+      const normalized = normalizeHref(href);
+      if (!normalized) continue;
+      if (seen.has(normalized.url)) continue;
+      const isInternal = sameHost(normalized.url, entryHost);
+      seen.set(normalized.url, { url: normalized.url, isInternal, sourcePage: pageUrl });
+    }
+  } finally {
+    await page.close().catch(() => {});
+  }
+}
+
+function normalizeHref(href: string): { url: string } | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(href);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  parsed.hash = "";
+  return { url: parsed.toString() };
+}
+
+function sameHost(url: string, host: string): boolean {
+  try {
+    return new URL(url).hostname.toLowerCase() === host;
+  } catch {
+    return false;
+  }
+}
+
+async function checkLinks(
+  request: APIRequestContext,
+  links: DiscoveredLink[],
+): Promise<LinkResult[]> {
+  const results: LinkResult[] = new Array(links.length);
+  let cursor = 0;
+
+  const runners = Array.from(
+    { length: Math.min(REQUEST_CONCURRENCY, links.length) },
+    async () => {
+      while (true) {
+        const idx = cursor++;
+        if (idx >= links.length) return;
+        results[idx] = await checkOne(request, links[idx]);
+      }
+    },
+  );
+  await Promise.all(runners);
+  return results;
+}
+
+async function checkOne(request: APIRequestContext, link: DiscoveredLink): Promise<LinkResult> {
+  const start = performance.now();
+  const headOutcome = await tryRequest(request, link.url, "head");
+  let outcome = headOutcome;
+
+  // Some servers reject HEAD with 4xx/5xx or close the connection. Retry with GET in those cases
+  // to avoid false negatives. We always release the body to avoid downloading large pages.
+  const shouldRetryWithGet =
+    outcome.kind === "error" ||
+    (outcome.kind === "status" &&
+      (outcome.statusCode === 405 || outcome.statusCode === 501 || outcome.statusCode >= 500));
+  if (shouldRetryWithGet) {
+    outcome = await tryRequest(request, link.url, "get");
+  }
+
+  const durationMs = Math.round(performance.now() - start);
+
+  if (outcome.kind === "status") {
+    return {
+      url: link.url,
+      statusCode: outcome.statusCode,
+      status: classifyStatus(outcome.statusCode),
+      isInternal: link.isInternal,
+      durationMs,
+      sourcePage: link.sourcePage,
+    };
+  }
+  return {
+    url: link.url,
+    statusCode: null,
+    status: outcome.timeout ? "timeout" : "network-error",
+    isInternal: link.isInternal,
+    durationMs,
+    sourcePage: link.sourcePage,
+  };
+}
+
+type RequestOutcome =
+  | { kind: "status"; statusCode: number }
+  | { kind: "error"; timeout: boolean };
+
+async function tryRequest(
+  request: APIRequestContext,
+  url: string,
+  method: "head" | "get",
+): Promise<RequestOutcome> {
+  try {
+    const res =
+      method === "head"
+        ? await request.head(url, { timeout: LINK_REQUEST_TIMEOUT_MS, maxRedirects: 0 })
+        : await request.get(url, { timeout: LINK_REQUEST_TIMEOUT_MS, maxRedirects: 0 });
+    const statusCode = res.status();
+    // Release the body to free memory; we never read it.
+    await res.dispose().catch(() => {});
+    return { kind: "status", statusCode };
+  } catch (e) {
+    const timeout = e instanceof Error && (e.name === "TimeoutError" || /timeout/i.test(e.message));
+    return { kind: "error", timeout };
+  }
+}
+
+function errorResponse(status: number, errorCode: string, message: string): Response {
+  return NextResponse.json({ error: message, errorCode }, { status });
+}

--- a/src/app/api/broken-link-checker/route.ts
+++ b/src/app/api/broken-link-checker/route.ts
@@ -236,6 +236,21 @@ async function checkLinks(
 
 async function checkOne(request: APIRequestContext, link: DiscoveredLink): Promise<LinkResult> {
   const start = performance.now();
+
+  // SSRF guard: discovered hrefs are untrusted. Refuse to fetch URLs that point at
+  // localhost / private / link-local addresses (e.g. cloud metadata endpoints).
+  const validation = validateRequestUrl(link.url);
+  if (!validation.ok) {
+    return {
+      url: link.url,
+      statusCode: null,
+      status: "blocked",
+      isInternal: link.isInternal,
+      durationMs: 0,
+      sourcePage: link.sourcePage,
+    };
+  }
+
   const headOutcome = await tryRequest(request, link.url, "head");
   let outcome = headOutcome;
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, ArrowLeftRight, Braces, Calculator, Camera, Clock, Cloud, Coins, FileText, Fingerprint, FileDiff, Gauge, Github, Globe, Languages, Palette, Package, QrCode, Regex, ScanSearch, Send, Timer, Type, type LucideIcon } from "lucide-react";
+import { ArrowRight, ArrowLeftRight, Braces, Calculator, Camera, Clock, Cloud, Coins, FileText, Fingerprint, FileDiff, Gauge, Github, Globe, Languages, Link2Off, Palette, Package, QrCode, Regex, ScanSearch, Send, Timer, Type, type LucideIcon } from "lucide-react";
 import {
   Card,
   CardHeader,
@@ -180,6 +180,13 @@ const tools: Tool[] = [
     description: "URLからWeb Vitals相当（LCP/CLS/FCP/TBT）・読み込みタイミング・リソース一覧を計測し、デスクトップ/モバイルで比較",
     href: "/tools/page-performance-checker",
     icon: Gauge,
+    category: "playwright",
+  },
+  {
+    name: "リンク切れチェッカー",
+    description: "URLを入力するとPlaywrightでページ内の全リンクをクロールし、404/500/リダイレクト等のステータスと内部/外部分類を一覧化、CSVエクスポート対応",
+    href: "/tools/broken-link-checker",
+    icon: Link2Off,
     category: "playwright",
   },
 ];

--- a/src/app/tools/broken-link-checker/page.tsx
+++ b/src/app/tools/broken-link-checker/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
 import { BrokenLinkCheckerPage } from "@/features/broken-link-checker/components/broken-link-checker-page";
+
+export const metadata: Metadata = {
+  title: "リンク切れチェッカー - Personal Tools",
+  description:
+    "URLを入力するとPlaywrightでページ内の全リンクをクロールし、404/500/リダイレクト等のステータスと内部/外部分類を一覧化、CSVエクスポート対応",
+};
 
 export default function Page() {
   return <BrokenLinkCheckerPage />;

--- a/src/app/tools/broken-link-checker/page.tsx
+++ b/src/app/tools/broken-link-checker/page.tsx
@@ -1,0 +1,5 @@
+import { BrokenLinkCheckerPage } from "@/features/broken-link-checker/components/broken-link-checker-page";
+
+export default function Page() {
+  return <BrokenLinkCheckerPage />;
+}

--- a/src/features/broken-link-checker/components/__tests__/checker-form.test.tsx
+++ b/src/features/broken-link-checker/components/__tests__/checker-form.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CheckerForm } from "../checker-form";
+
+describe("CheckerForm", () => {
+  it("disables submit when URL is empty", () => {
+    render(
+      <CheckerForm
+        url=""
+        depth={1}
+        isLoading={false}
+        onUrlChange={() => {}}
+        onDepthChange={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "チェックする" })).toBeDisabled();
+  });
+
+  it("disables submit and shows loading label while loading", () => {
+    render(
+      <CheckerForm
+        url="https://example.com"
+        depth={1}
+        isLoading={true}
+        onUrlChange={() => {}}
+        onDepthChange={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "チェック中…" })).toBeDisabled();
+  });
+
+  it("calls onSubmit when the user submits a valid URL", async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn();
+    render(
+      <CheckerForm
+        url="https://example.com"
+        depth={1}
+        isLoading={false}
+        onUrlChange={() => {}}
+        onDepthChange={() => {}}
+        onSubmit={onSubmit}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "チェックする" }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onSubmit when URL is whitespace only", async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn();
+    render(
+      <CheckerForm
+        url="   "
+        depth={1}
+        isLoading={false}
+        onUrlChange={() => {}}
+        onDepthChange={() => {}}
+        onSubmit={onSubmit}
+      />,
+    );
+    const button = screen.getByRole("button", { name: "チェックする" });
+    expect(button).toBeDisabled();
+    await user.click(button);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("emits typed input via onUrlChange", async () => {
+    const user = userEvent.setup();
+    const onUrlChange = jest.fn();
+    render(
+      <CheckerForm
+        url=""
+        depth={1}
+        isLoading={false}
+        onUrlChange={onUrlChange}
+        onDepthChange={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    const input = screen.getByLabelText("URL");
+    await user.type(input, "h");
+    expect(onUrlChange).toHaveBeenCalledWith("h");
+  });
+});

--- a/src/features/broken-link-checker/components/broken-link-checker-page.tsx
+++ b/src/features/broken-link-checker/components/broken-link-checker-page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { AlertCircle } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { checkLinks } from "@/features/broken-link-checker/lib/checker-client";
+import type {
+  CheckerError,
+  CheckerResponse,
+  Depth,
+} from "@/features/broken-link-checker/lib/types";
+import { CheckerForm } from "./checker-form";
+import { CheckerResult } from "./checker-result";
+
+export function BrokenLinkCheckerPage() {
+  const [url, setUrl] = useState("");
+  const [depth, setDepth] = useState<Depth>(1);
+  const [result, setResult] = useState<CheckerResponse | null>(null);
+  const [error, setError] = useState<CheckerError | undefined>();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = useCallback(async () => {
+    if (isLoading) return;
+    setIsLoading(true);
+    setResult(null);
+    setError(undefined);
+
+    const res = await checkLinks({ url: url.trim(), depth });
+    if (res.ok) {
+      setResult(res.data);
+    } else {
+      setError(res.error);
+    }
+    setIsLoading(false);
+  }, [depth, isLoading, url]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">リンク切れチェッカー</h1>
+        <p className="mt-2 text-muted-foreground">
+          URL を入力すると、サーバー側 Playwright がページ内の全リンクをクロールし、
+          ステータスコード（200 / 404 / 500 / リダイレクト等）を一覧化します。
+          内部 / 外部リンクの分類、エラーのみのフィルタ、CSV エクスポートに対応します。
+        </p>
+      </div>
+
+      <CheckerForm
+        url={url}
+        depth={depth}
+        isLoading={isLoading}
+        onUrlChange={setUrl}
+        onDepthChange={setDepth}
+        onSubmit={handleSubmit}
+      />
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" aria-hidden="true" />
+          <AlertTitle>チェックに失敗しました</AlertTitle>
+          <AlertDescription>{error.error}</AlertDescription>
+        </Alert>
+      )}
+
+      <CheckerResult result={result} isLoading={isLoading} />
+    </div>
+  );
+}

--- a/src/features/broken-link-checker/components/checker-form.tsx
+++ b/src/features/broken-link-checker/components/checker-form.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Link2Off, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  DEPTHS,
+  DEPTH_LABELS,
+  isDepth,
+  type Depth,
+} from "@/features/broken-link-checker/lib/types";
+
+type Props = {
+  url: string;
+  depth: Depth;
+  isLoading: boolean;
+  onUrlChange: (url: string) => void;
+  onDepthChange: (depth: Depth) => void;
+  onSubmit: () => void;
+};
+
+export function CheckerForm({
+  url,
+  depth,
+  isLoading,
+  onUrlChange,
+  onDepthChange,
+  onSubmit,
+}: Props) {
+  const canSubmit = url.trim().length > 0 && !isLoading;
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (canSubmit) onSubmit();
+      }}
+    >
+      <div className="space-y-2">
+        <Label htmlFor="checker-url">URL</Label>
+        <Input
+          id="checker-url"
+          type="url"
+          inputMode="url"
+          autoComplete="off"
+          placeholder="https://example.com"
+          value={url}
+          onChange={(e) => onUrlChange(e.target.value)}
+          disabled={isLoading}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="checker-depth">クロール階層</Label>
+        <Select
+          value={String(depth)}
+          onValueChange={(value) => {
+            const parsed = Number(value);
+            if (isDepth(parsed)) onDepthChange(parsed);
+          }}
+          disabled={isLoading}
+        >
+          <SelectTrigger id="checker-depth" className="w-60">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {DEPTHS.map((d) => (
+              <SelectItem key={d} value={String(d)}>
+                {DEPTH_LABELS[d]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          2階層を選ぶと、入力URLに加えて見つかった内部リンク先（最大5ページ）も追加でクロールします。
+        </p>
+      </div>
+
+      <div>
+        <Button type="submit" disabled={!canSubmit}>
+          {isLoading ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <Link2Off className="h-4 w-4" aria-hidden="true" />
+          )}
+          {isLoading ? "チェック中…" : "チェックする"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/features/broken-link-checker/components/checker-result.tsx
+++ b/src/features/broken-link-checker/components/checker-result.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Download } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { downloadCsv, toCsv } from "@/lib/csv-export";
+import {
+  LINK_STATUS_LABELS,
+  isErrorStatus,
+  type CheckerResponse,
+  type LinkStatus,
+} from "@/features/broken-link-checker/lib/types";
+
+type Props = {
+  result: CheckerResponse | null;
+  isLoading: boolean;
+};
+
+type FilterMode = "all" | "errors";
+
+const STATUS_BADGE_VARIANT: Record<LinkStatus, "secondary" | "outline" | "destructive"> = {
+  ok: "secondary",
+  redirect: "outline",
+  "client-error": "destructive",
+  "server-error": "destructive",
+  "network-error": "destructive",
+  timeout: "destructive",
+};
+
+const STATUS_BADGE_CLASS: Partial<Record<LinkStatus, string>> = {
+  ok: "bg-emerald-100 text-emerald-900 dark:bg-emerald-950 dark:text-emerald-200",
+  redirect: "bg-amber-100 text-amber-900 border-amber-300 dark:bg-amber-950 dark:text-amber-200 dark:border-amber-800",
+};
+
+export function CheckerResult({ result, isLoading }: Props) {
+  const [filter, setFilter] = useState<FilterMode>("all");
+
+  const errorCount = useMemo(
+    () => (result ? result.links.filter((l) => isErrorStatus(l.status)).length : 0),
+    [result],
+  );
+
+  const visibleLinks = useMemo(() => {
+    if (!result) return [];
+    return filter === "errors" ? result.links.filter((l) => isErrorStatus(l.status)) : result.links;
+  }, [result, filter]);
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">チェック中…</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-48 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!result) return null;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-4">
+        <div className="space-y-1">
+          <CardTitle className="text-base">チェック結果</CardTitle>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+            <span>発見: {result.totalFound} 件</span>
+            <span>チェック: {result.totalChecked} 件</span>
+            <span>エラー: <span className={errorCount > 0 ? "font-semibold text-rose-600 dark:text-rose-400" : ""}>{errorCount} 件</span></span>
+            <span>所要時間: {(result.durationMs / 1000).toFixed(1)} 秒</span>
+            {result.truncated && (
+              <Badge variant="outline" className="border-amber-300 text-amber-900 dark:border-amber-800 dark:text-amber-200">
+                上限により切り捨て
+              </Badge>
+            )}
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => exportCsv(result)}
+          disabled={result.links.length === 0}
+        >
+          <Download className="h-4 w-4" aria-hidden="true" />
+          CSV
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Tabs value={filter} onValueChange={(v) => setFilter(v as FilterMode)}>
+          <TabsList>
+            <TabsTrigger value="all">全て ({result.links.length})</TabsTrigger>
+            <TabsTrigger value="errors">エラーのみ ({errorCount})</TabsTrigger>
+          </TabsList>
+        </Tabs>
+
+        {visibleLinks.length === 0 ? (
+          <p className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+            {filter === "errors" ? "エラーのリンクはありません。" : "リンクが見つかりませんでした。"}
+          </p>
+        ) : (
+          <div className="overflow-x-auto rounded-md border">
+            <table className="w-full text-xs">
+              <thead className="bg-muted/30">
+                <tr>
+                  <th className="px-3 py-2 text-left font-medium">ステータス</th>
+                  <th className="px-3 py-2 text-left font-medium">URL</th>
+                  <th className="px-3 py-2 text-left font-medium">種別</th>
+                  {result.depth === 2 && (
+                    <th className="px-3 py-2 text-left font-medium">検出元ページ</th>
+                  )}
+                  <th className="px-3 py-2 text-right font-medium">応答時間</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleLinks.map((link) => (
+                  <tr key={link.url} className="border-t">
+                    <td className="px-3 py-1.5 whitespace-nowrap">
+                      <Badge
+                        variant={STATUS_BADGE_VARIANT[link.status]}
+                        className={STATUS_BADGE_CLASS[link.status]}
+                      >
+                        {link.statusCode ?? "-"} · {LINK_STATUS_LABELS[link.status]}
+                      </Badge>
+                    </td>
+                    <td className="max-w-[420px] truncate px-3 py-1.5 font-mono">
+                      <a href={link.url} target="_blank" rel="noreferrer noopener" title={link.url} className="hover:underline">
+                        {link.url}
+                      </a>
+                    </td>
+                    <td className="px-3 py-1.5">{link.isInternal ? "内部" : "外部"}</td>
+                    {result.depth === 2 && (
+                      <td className="max-w-[260px] truncate px-3 py-1.5 font-mono text-muted-foreground" title={link.sourcePage}>
+                        {link.sourcePage}
+                      </td>
+                    )}
+                    <td className="px-3 py-1.5 text-right tabular-nums">{link.durationMs}ms</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function exportCsv(result: CheckerResponse) {
+  const headers = ["status_code", "status", "url", "type", "source_page", "duration_ms"];
+  const rows = result.links.map((l) => [
+    l.statusCode ?? "",
+    LINK_STATUS_LABELS[l.status],
+    l.url,
+    l.isInternal ? "internal" : "external",
+    l.sourcePage,
+    l.durationMs,
+  ]);
+  const csv = toCsv(headers, rows);
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  downloadCsv(csv, `broken-link-check-${stamp}.csv`);
+}

--- a/src/features/broken-link-checker/components/checker-result.tsx
+++ b/src/features/broken-link-checker/components/checker-result.tsx
@@ -29,6 +29,7 @@ const STATUS_BADGE_VARIANT: Record<LinkStatus, "secondary" | "outline" | "destru
   "server-error": "destructive",
   "network-error": "destructive",
   timeout: "destructive",
+  blocked: "destructive",
 };
 
 const STATUS_BADGE_CLASS: Partial<Record<LinkStatus, string>> = {

--- a/src/features/broken-link-checker/lib/__tests__/types.test.ts
+++ b/src/features/broken-link-checker/lib/__tests__/types.test.ts
@@ -1,0 +1,62 @@
+import {
+  DEPTHS,
+  classifyStatus,
+  isDepth,
+  isErrorStatus,
+} from "@/features/broken-link-checker/lib/types";
+
+describe("isDepth", () => {
+  it("accepts each value in DEPTHS", () => {
+    for (const d of DEPTHS) {
+      expect(isDepth(d)).toBe(true);
+    }
+  });
+
+  it("rejects values outside DEPTHS", () => {
+    expect(isDepth(0)).toBe(false);
+    expect(isDepth(3)).toBe(false);
+    expect(isDepth("1")).toBe(false);
+    expect(isDepth(null)).toBe(false);
+    expect(isDepth(undefined)).toBe(false);
+  });
+});
+
+describe("classifyStatus", () => {
+  it("returns 'ok' for 2xx", () => {
+    expect(classifyStatus(200)).toBe("ok");
+    expect(classifyStatus(204)).toBe("ok");
+    expect(classifyStatus(299)).toBe("ok");
+  });
+
+  it("returns 'redirect' for 3xx", () => {
+    expect(classifyStatus(301)).toBe("redirect");
+    expect(classifyStatus(302)).toBe("redirect");
+    expect(classifyStatus(308)).toBe("redirect");
+  });
+
+  it("returns 'client-error' for 4xx", () => {
+    expect(classifyStatus(400)).toBe("client-error");
+    expect(classifyStatus(404)).toBe("client-error");
+    expect(classifyStatus(499)).toBe("client-error");
+  });
+
+  it("returns 'server-error' for 5xx and beyond", () => {
+    expect(classifyStatus(500)).toBe("server-error");
+    expect(classifyStatus(503)).toBe("server-error");
+    expect(classifyStatus(599)).toBe("server-error");
+  });
+});
+
+describe("isErrorStatus", () => {
+  it("flags client/server/network/timeout as errors", () => {
+    expect(isErrorStatus("client-error")).toBe(true);
+    expect(isErrorStatus("server-error")).toBe(true);
+    expect(isErrorStatus("network-error")).toBe(true);
+    expect(isErrorStatus("timeout")).toBe(true);
+  });
+
+  it("does not flag ok/redirect as errors", () => {
+    expect(isErrorStatus("ok")).toBe(false);
+    expect(isErrorStatus("redirect")).toBe(false);
+  });
+});

--- a/src/features/broken-link-checker/lib/__tests__/types.test.ts
+++ b/src/features/broken-link-checker/lib/__tests__/types.test.ts
@@ -48,11 +48,12 @@ describe("classifyStatus", () => {
 });
 
 describe("isErrorStatus", () => {
-  it("flags client/server/network/timeout as errors", () => {
+  it("flags client/server/network/timeout/blocked as errors", () => {
     expect(isErrorStatus("client-error")).toBe(true);
     expect(isErrorStatus("server-error")).toBe(true);
     expect(isErrorStatus("network-error")).toBe(true);
     expect(isErrorStatus("timeout")).toBe(true);
+    expect(isErrorStatus("blocked")).toBe(true);
   });
 
   it("does not flag ok/redirect as errors", () => {

--- a/src/features/broken-link-checker/lib/checker-client.ts
+++ b/src/features/broken-link-checker/lib/checker-client.ts
@@ -1,0 +1,59 @@
+import type {
+  CheckerError,
+  CheckerOptions,
+  CheckerResponse,
+} from "@/features/broken-link-checker/lib/types";
+
+export type CheckResult =
+  | { ok: true; data: CheckerResponse }
+  | { ok: false; error: CheckerError; status: number };
+
+export async function checkLinks(
+  options: CheckerOptions,
+  signal?: AbortSignal,
+): Promise<CheckResult> {
+  let response: Response;
+  try {
+    response = await fetch("/api/broken-link-checker", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(options),
+      signal,
+    });
+  } catch (e) {
+    const aborted = e instanceof DOMException && e.name === "AbortError";
+    return {
+      ok: false,
+      status: 0,
+      error: {
+        error: aborted ? "リクエストが中断されました。" : "サーバーに接続できませんでした。",
+        errorCode: aborted ? "ABORTED" : "NETWORK_ERROR",
+      },
+    };
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    return {
+      ok: false,
+      status: response.status,
+      error: { error: "サーバーからの応答を解析できませんでした。", errorCode: "PARSE_ERROR" },
+    };
+  }
+
+  if (!response.ok) {
+    const err = payload as Partial<CheckerError>;
+    return {
+      ok: false,
+      status: response.status,
+      error: {
+        error: err.error ?? `エラー (${response.status})`,
+        errorCode: err.errorCode ?? "UNKNOWN_ERROR",
+      },
+    };
+  }
+
+  return { ok: true, data: payload as CheckerResponse };
+}

--- a/src/features/broken-link-checker/lib/types.ts
+++ b/src/features/broken-link-checker/lib/types.ts
@@ -13,6 +13,7 @@ export const LINK_STATUSES = [
   "server-error",
   "network-error",
   "timeout",
+  "blocked",
 ] as const;
 export type LinkStatus = (typeof LINK_STATUSES)[number];
 
@@ -23,6 +24,7 @@ export const LINK_STATUS_LABELS: Record<LinkStatus, string> = {
   "server-error": "サーバーエラー",
   "network-error": "到達不能",
   timeout: "タイムアウト",
+  blocked: "ブロック",
 };
 
 export type LinkResult = {
@@ -71,5 +73,11 @@ export function classifyStatus(statusCode: number): LinkStatus {
 }
 
 export function isErrorStatus(status: LinkStatus): boolean {
-  return status === "client-error" || status === "server-error" || status === "network-error" || status === "timeout";
+  return (
+    status === "client-error" ||
+    status === "server-error" ||
+    status === "network-error" ||
+    status === "timeout" ||
+    status === "blocked"
+  );
 }

--- a/src/features/broken-link-checker/lib/types.ts
+++ b/src/features/broken-link-checker/lib/types.ts
@@ -1,0 +1,75 @@
+export const DEPTHS = [1, 2] as const;
+export type Depth = (typeof DEPTHS)[number];
+
+export const DEPTH_LABELS: Record<Depth, string> = {
+  1: "1階層のみ",
+  2: "2階層まで",
+};
+
+export const LINK_STATUSES = [
+  "ok",
+  "redirect",
+  "client-error",
+  "server-error",
+  "network-error",
+  "timeout",
+] as const;
+export type LinkStatus = (typeof LINK_STATUSES)[number];
+
+export const LINK_STATUS_LABELS: Record<LinkStatus, string> = {
+  ok: "OK",
+  redirect: "リダイレクト",
+  "client-error": "クライアントエラー",
+  "server-error": "サーバーエラー",
+  "network-error": "到達不能",
+  timeout: "タイムアウト",
+};
+
+export type LinkResult = {
+  url: string;
+  statusCode: number | null;
+  status: LinkStatus;
+  isInternal: boolean;
+  durationMs: number;
+  sourcePage: string;
+};
+
+export type CheckerOptions = {
+  url: string;
+  depth: Depth;
+};
+
+export type CheckerResponse = {
+  url: string;
+  depth: Depth;
+  links: LinkResult[];
+  totalFound: number;
+  totalChecked: number;
+  truncated: boolean;
+  durationMs: number;
+};
+
+export type CheckerError = {
+  error: string;
+  errorCode: string;
+};
+
+export const MAX_LINKS_TO_CHECK = 200;
+export const REQUEST_CONCURRENCY = 5;
+export const LINK_REQUEST_TIMEOUT_MS = 10_000;
+export const NAVIGATION_TIMEOUT_MS = 20_000;
+
+export function isDepth(value: unknown): value is Depth {
+  return typeof value === "number" && (DEPTHS as readonly number[]).includes(value);
+}
+
+export function classifyStatus(statusCode: number): LinkStatus {
+  if (statusCode >= 200 && statusCode < 300) return "ok";
+  if (statusCode >= 300 && statusCode < 400) return "redirect";
+  if (statusCode >= 400 && statusCode < 500) return "client-error";
+  return "server-error";
+}
+
+export function isErrorStatus(status: LinkStatus): boolean {
+  return status === "client-error" || status === "server-error" || status === "network-error" || status === "timeout";
+}

--- a/src/lib/__tests__/csv-export.test.ts
+++ b/src/lib/__tests__/csv-export.test.ts
@@ -1,0 +1,37 @@
+import { toCsv } from "@/lib/csv-export";
+
+describe("toCsv", () => {
+  it("joins headers and rows with CRLF", () => {
+    const csv = toCsv(["a", "b"], [["1", "2"], ["3", "4"]]);
+    expect(csv).toBe("a,b\r\n1,2\r\n3,4");
+  });
+
+  it("escapes cells containing commas with double quotes", () => {
+    const csv = toCsv(["name"], [["foo, bar"]]);
+    expect(csv).toBe('name\r\n"foo, bar"');
+  });
+
+  it("escapes embedded double quotes by doubling them", () => {
+    const csv = toCsv(["name"], [['he said "hi"']]);
+    expect(csv).toBe('name\r\n"he said ""hi"""');
+  });
+
+  it("escapes cells containing CR or LF", () => {
+    const csv = toCsv(["text"], [["line1\nline2"]]);
+    expect(csv).toBe('text\r\n"line1\nline2"');
+  });
+
+  it("renders null and undefined as empty strings", () => {
+    const csv = toCsv(["a", "b", "c"], [[null, undefined, "x"]]);
+    expect(csv).toBe("a,b,c\r\n,,x");
+  });
+
+  it("stringifies numbers and booleans", () => {
+    const csv = toCsv(["n", "b"], [[42, true]]);
+    expect(csv).toBe("n,b\r\n42,true");
+  });
+
+  it("returns just the header row when rows is empty", () => {
+    expect(toCsv(["x"], [])).toBe("x");
+  });
+});

--- a/src/lib/csv-export.ts
+++ b/src/lib/csv-export.ts
@@ -18,8 +18,8 @@ function escapeCell(value: CsvCell): string {
 }
 
 export function downloadCsv(content: string, filename: string): void {
-  // BOM to ensure Excel reads UTF-8 correctly
-  const blob = new Blob(["﻿", content], { type: "text/csv;charset=utf-8" });
+  // BOM (U+FEFF) to ensure Excel reads UTF-8 correctly
+  const blob = new Blob(["\uFEFF", content], { type: "text/csv;charset=utf-8" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;

--- a/src/lib/csv-export.ts
+++ b/src/lib/csv-export.ts
@@ -1,0 +1,31 @@
+export type CsvCell = string | number | boolean | null | undefined;
+
+export function toCsv(headers: string[], rows: CsvCell[][]): string {
+  const lines = [headers.map(escapeCell).join(",")];
+  for (const row of rows) {
+    lines.push(row.map(escapeCell).join(","));
+  }
+  return lines.join("\r\n");
+}
+
+function escapeCell(value: CsvCell): string {
+  if (value === null || value === undefined) return "";
+  const str = String(value);
+  if (/[",\r\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+export function downloadCsv(content: string, filename: string): void {
+  // BOM to ensure Excel reads UTF-8 correctly
+  const blob = new Blob(["﻿", content], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- ページ内の全リンクを Playwright でクロールし、ステータスコード (200 / 404 / 500 / リダイレクト等) を一覧化する新ツール `broken-link-checker` を追加
- 内部 / 外部リンクの分類、エラーのみのフィルタタブ、CSV エクスポート (BOM 付き UTF-8 / RFC 4180 クォート) に対応
- depth=1 (入力URLのみ) / depth=2 (入力URL + 内部リンク先頭5ページを追加クロール) を選択可能
- リンク確認は HEAD 優先、405/501/5xx 時に GET フォールバックで false negative を回避
- サーバー負荷対策として 検査リンク総数 200件 / 同時接続 5 / リンク 10秒タイムアウト / レート制限 5req/60秒 を設定
- 汎用ユーティリティ `src/lib/csv-export.ts` を新設

Closes #42

## Test plan
- [x] `npm run lint` — クリーン
- [x] `npm run test` — 51 suites / 669 tests pass (新規 20 件含む)
- [x] `npm run build` — 成功 (`/api/broken-link-checker` と `/tools/broken-link-checker` 登録)
- [x] API 動作確認: `https://example.com` で depth=1 → 1件 (301 redirect) 検出
- [x] バリデーション: invalid URL / localhost (blocked) / 不正な depth → 400 を返却
- [ ] ブラウザでの実画面確認 (フォーム送信 → 結果テーブル表示 → エラータブ → CSV ダウンロード)
- [ ] depth=2 で内部リンクが追加クロールされること
- [ ] 連続 6 回送信でレート制限 (429) 表示

## 補足
- ファイル数 12 / 1000 行は PR サイズ目安 (10 / 300) を超えますが、新規ディレクトリ配下で完結する新機能のため共通開発規約の「新機能の新規ディレクトリ追加」例外条項に該当します

🤖 Generated with [Claude Code](https://claude.com/claude-code)