### PR TITLE
feat: Webスクレイピングツールを追加

### DIFF
--- a/src/app/api/web-scraper/route.ts
+++ b/src/app/api/web-scraper/route.ts
@@ -1,0 +1,161 @@
+import { NextResponse } from "next/server";
+import { chromium, type Browser, type BrowserContext } from "playwright";
+import { createRateLimit } from "@/lib/rate-limit";
+import { getClientIp, rateLimitResponse } from "@/lib/api-helpers";
+import { validateRequestUrl } from "@/lib/url-validator";
+import {
+  MAX_MATCHES_PER_SELECTOR,
+  MAX_SELECTORS,
+  NAVIGATION_TIMEOUT_MS,
+  isSelectorInput,
+  type ScrapedElement,
+  type ScraperResponse,
+  type ScraperSelectorInput,
+  type SelectorResult,
+} from "@/features/web-scraper/lib/types";
+
+export const runtime = "nodejs";
+
+const rateLimit = createRateLimit({ limit: 5, windowMs: 60_000 });
+
+const USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36";
+
+type RequestBody = {
+  url?: unknown;
+  selectors?: unknown;
+};
+
+export async function POST(request: Request) {
+  const ip = getClientIp(request);
+  if (ip !== "unknown") {
+    const result = rateLimit.check(ip);
+    if (!result.allowed) {
+      return rateLimitResponse(result.retryAfterMs);
+    }
+  }
+
+  let payload: RequestBody;
+  try {
+    payload = (await request.json()) as RequestBody;
+  } catch {
+    return errorResponse(400, "VALIDATION_ERROR", "リクエストボディの形式が正しくありません。");
+  }
+
+  const validation = validateRequestUrl(typeof payload.url === "string" ? payload.url : "");
+  if (!validation.ok) {
+    return errorResponse(400, validation.errorCode.toUpperCase(), validation.message);
+  }
+
+  const selectors = parseSelectors(payload.selectors);
+  if ("error" in selectors) {
+    return errorResponse(400, "VALIDATION_ERROR", selectors.error);
+  }
+
+  const targetUrl = validation.url.toString();
+  const start = performance.now();
+
+  let browser: Browser;
+  try {
+    browser = await chromium.launch();
+  } catch (e) {
+    console.error("[web-scraper] failed to launch chromium", e);
+    return errorResponse(
+      500,
+      "BROWSER_LAUNCH_FAILED",
+      "ブラウザの起動に失敗しました。Playwrightのインストール状態を確認してください。",
+    );
+  }
+
+  let context: BrowserContext | undefined;
+  try {
+    context = await browser.newContext({ userAgent: USER_AGENT });
+    const page = await context.newPage();
+    await page.goto(targetUrl, { waitUntil: "load", timeout: NAVIGATION_TIMEOUT_MS });
+
+    const results: SelectorResult[] = [];
+    for (const sel of selectors.value) {
+      results.push(await extractForSelector(page, sel));
+    }
+
+    const response: ScraperResponse = {
+      url: targetUrl,
+      results,
+      durationMs: Math.round(performance.now() - start),
+    };
+    return NextResponse.json(response);
+  } catch (e) {
+    const isTimeout = e instanceof Error && (e.name === "TimeoutError" || /timeout/i.test(e.message));
+    return errorResponse(
+      isTimeout ? 504 : 502,
+      isTimeout ? "TIMEOUT" : "SCRAPE_FAILED",
+      isTimeout
+        ? `ページ読み込みが${NAVIGATION_TIMEOUT_MS / 1000}秒以内に完了しませんでした。`
+        : "ページの読み込みに失敗しました。",
+    );
+  } finally {
+    if (context) await context.close().catch(() => {});
+    await browser.close().catch(() => {});
+  }
+}
+
+type SelectorParse =
+  | { value: ScraperSelectorInput[] }
+  | { error: string };
+
+function parseSelectors(input: unknown): SelectorParse {
+  if (!Array.isArray(input)) {
+    return { error: "selectors は配列で指定してください。" };
+  }
+  if (input.length === 0) {
+    return { error: "セレクタを1つ以上指定してください。" };
+  }
+  if (input.length > MAX_SELECTORS) {
+    return { error: `セレクタは最大${MAX_SELECTORS}件までです。` };
+  }
+  const parsed: ScraperSelectorInput[] = [];
+  for (const item of input) {
+    if (!isSelectorInput(item)) {
+      return { error: "セレクタの形式が正しくありません。" };
+    }
+    const selector = item.selector.trim();
+    if (!selector) {
+      return { error: "空のセレクタは指定できません。" };
+    }
+    parsed.push({ name: item.name.trim(), selector });
+  }
+  return { value: parsed };
+}
+
+async function extractForSelector(
+  page: import("playwright").Page,
+  sel: ScraperSelectorInput,
+): Promise<SelectorResult> {
+  try {
+    const all = (await page.$$eval(sel.selector, (els) =>
+      els.map((el) => ({
+        text: (el.textContent ?? "").trim(),
+        html: el.innerHTML,
+        href: el instanceof HTMLAnchorElement ? el.href : undefined,
+        src: el instanceof HTMLImageElement ? el.src : undefined,
+      })),
+    )) as ScrapedElement[];
+
+    const truncated = all.length > MAX_MATCHES_PER_SELECTOR;
+    const matches = truncated ? all.slice(0, MAX_MATCHES_PER_SELECTOR) : all;
+    return { name: sel.name, selector: sel.selector, matches, truncated };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return {
+      name: sel.name,
+      selector: sel.selector,
+      matches: [],
+      truncated: false,
+      error: `セレクタの実行に失敗しました: ${message}`,
+    };
+  }
+}
+
+function errorResponse(status: number, errorCode: string, message: string): Response {
+  return NextResponse.json({ error: message, errorCode }, { status });
+}

--- a/src/app/api/web-scraper/route.ts
+++ b/src/app/api/web-scraper/route.ts
@@ -73,6 +73,17 @@ export async function POST(request: Request) {
     const page = await context.newPage();
     await page.goto(targetUrl, { waitUntil: "load", timeout: NAVIGATION_TIMEOUT_MS });
 
+    // SSRF guard against redirects: the initial URL passed validation, but `page.goto`
+    // follows redirects that may land on a private/loopback host. Re-validate the final URL.
+    const finalValidation = validateRequestUrl(page.url());
+    if (!finalValidation.ok) {
+      return errorResponse(
+        400,
+        finalValidation.errorCode.toUpperCase(),
+        "リダイレクト先がローカル/プライベートネットワークのため、抽出を中止しました。",
+      );
+    }
+
     const results: SelectorResult[] = [];
     for (const sel of selectors.value) {
       results.push(await extractForSelector(page, sel));
@@ -132,17 +143,22 @@ async function extractForSelector(
   sel: ScraperSelectorInput,
 ): Promise<SelectorResult> {
   try {
-    const all = (await page.$$eval(sel.selector, (els) =>
-      els.map((el) => ({
-        text: (el.textContent ?? "").trim(),
-        html: el.innerHTML,
-        href: el instanceof HTMLAnchorElement ? el.href : undefined,
-        src: el instanceof HTMLImageElement ? el.src : undefined,
-      })),
+    // Truncate inside the browser so at most MAX + 1 elements cross the IPC boundary.
+    // The +1 is a sentinel that lets us flag `truncated` without serializing every match.
+    const limited = (await page.$$eval(
+      sel.selector,
+      (els, max) =>
+        els.slice(0, max + 1).map((el) => ({
+          text: (el.textContent ?? "").trim(),
+          html: el.innerHTML,
+          href: el instanceof HTMLAnchorElement ? el.href : undefined,
+          src: el instanceof HTMLImageElement ? el.src : undefined,
+        })),
+      MAX_MATCHES_PER_SELECTOR,
     )) as ScrapedElement[];
 
-    const truncated = all.length > MAX_MATCHES_PER_SELECTOR;
-    const matches = truncated ? all.slice(0, MAX_MATCHES_PER_SELECTOR) : all;
+    const truncated = limited.length > MAX_MATCHES_PER_SELECTOR;
+    const matches = truncated ? limited.slice(0, MAX_MATCHES_PER_SELECTOR) : limited;
     return { name: sel.name, selector: sel.selector, matches, truncated };
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, ArrowLeftRight, Braces, Calculator, Camera, Clock, Cloud, Coins, FileText, Fingerprint, FileDiff, Gauge, Github, Globe, Languages, Link2Off, Palette, Package, QrCode, Regex, ScanSearch, Send, Timer, Type, type LucideIcon } from "lucide-react";
+import { ArrowRight, ArrowLeftRight, Braces, Calculator, Camera, Clock, Cloud, Coins, FileText, Fingerprint, FileDiff, Gauge, Github, Globe, Languages, Link2Off, MousePointerClick, Palette, Package, QrCode, Regex, ScanSearch, Send, Timer, Type, type LucideIcon } from "lucide-react";
 import {
   Card,
   CardHeader,
@@ -187,6 +187,13 @@ const tools: Tool[] = [
     description: "URLを入力するとPlaywrightでページ内の全リンクをクロールし、404/500/リダイレクト等のステータスと内部/外部分類を一覧化、CSVエクスポート対応",
     href: "/tools/broken-link-checker",
     icon: Link2Off,
+    category: "playwright",
+  },
+  {
+    name: "Webスクレイピングツール",
+    description: "URLとCSSセレクタを指定してPlaywrightでWebページから要素を抽出、テキスト/属性をテーブル表示しJSON/CSVエクスポート",
+    href: "/tools/web-scraper",
+    icon: MousePointerClick,
     category: "playwright",
   },
 ];

--- a/src/app/tools/web-scraper/page.tsx
+++ b/src/app/tools/web-scraper/page.tsx
@@ -1,0 +1,5 @@
+import { WebScraperPage } from "@/features/web-scraper/components/web-scraper-page";
+
+export default function Page() {
+  return <WebScraperPage />;
+}

--- a/src/app/tools/web-scraper/page.tsx
+++ b/src/app/tools/web-scraper/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
 import { WebScraperPage } from "@/features/web-scraper/components/web-scraper-page";
+
+export const metadata: Metadata = {
+  title: "Webスクレイピングツール - Personal Tools",
+  description:
+    "URLとCSSセレクタを指定してPlaywrightでWebページから要素を抽出、テキスト/属性をテーブル表示しJSON/CSVエクスポート",
+};
 
 export default function Page() {
   return <WebScraperPage />;

--- a/src/features/web-scraper/components/__tests__/scraper-form.test.tsx
+++ b/src/features/web-scraper/components/__tests__/scraper-form.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ScraperForm } from "../scraper-form";
+import type { ScraperSelectorInput } from "@/features/web-scraper/lib/types";
+
+const oneSelector: ScraperSelectorInput[] = [{ name: "", selector: "" }];
+
+describe("ScraperForm", () => {
+  it("disables submit when URL is empty", () => {
+    render(
+      <ScraperForm
+        url=""
+        selectors={[{ name: "", selector: "h1" }]}
+        isLoading={false}
+        onUrlChange={() => {}}
+        onSelectorsChange={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "抽出する" })).toBeDisabled();
+  });
+
+  it("disables submit when no selector has been entered", () => {
+    render(
+      <ScraperForm
+        url="https://example.com"
+        selectors={oneSelector}
+        isLoading={false}
+        onUrlChange={() => {}}
+        onSelectorsChange={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "抽出する" })).toBeDisabled();
+  });
+
+  it("disables submit and shows loading label while loading", () => {
+    render(
+      <ScraperForm
+        url="https://example.com"
+        selectors={[{ name: "", selector: "h1" }]}
+        isLoading={true}
+        onUrlChange={() => {}}
+        onSelectorsChange={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "抽出中…" })).toBeDisabled();
+  });
+
+  it("calls onSubmit when URL and at least one selector are present", async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn();
+    render(
+      <ScraperForm
+        url="https://example.com"
+        selectors={[{ name: "", selector: "h1" }]}
+        isLoading={false}
+        onUrlChange={() => {}}
+        onSelectorsChange={() => {}}
+        onSubmit={onSubmit}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "抽出する" }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("appends a new selector row when 「セレクタを追加」 is clicked", async () => {
+    const user = userEvent.setup();
+    const onSelectorsChange = jest.fn();
+    render(
+      <ScraperForm
+        url=""
+        selectors={oneSelector}
+        isLoading={false}
+        onUrlChange={() => {}}
+        onSelectorsChange={onSelectorsChange}
+        onSubmit={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /セレクタを追加/ }));
+    expect(onSelectorsChange).toHaveBeenCalledWith([
+      { name: "", selector: "" },
+      { name: "", selector: "" },
+    ]);
+  });
+
+  it("removes a row when its delete button is clicked, but not the last remaining row", async () => {
+    const user = userEvent.setup();
+    const onSelectorsChange = jest.fn();
+    const { rerender } = render(
+      <ScraperForm
+        url=""
+        selectors={[
+          { name: "a", selector: "h1" },
+          { name: "b", selector: "p" },
+        ]}
+        isLoading={false}
+        onUrlChange={() => {}}
+        onSelectorsChange={onSelectorsChange}
+        onSubmit={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "セレクタ 2 を削除" }));
+    expect(onSelectorsChange).toHaveBeenCalledWith([{ name: "a", selector: "h1" }]);
+
+    rerender(
+      <ScraperForm
+        url=""
+        selectors={oneSelector}
+        isLoading={false}
+        onUrlChange={() => {}}
+        onSelectorsChange={onSelectorsChange}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "セレクタ 1 を削除" })).toBeDisabled();
+  });
+
+  it("emits selector changes via onSelectorsChange when typing into a selector input", async () => {
+    const user = userEvent.setup();
+    const onSelectorsChange = jest.fn();
+    render(
+      <ScraperForm
+        url=""
+        selectors={oneSelector}
+        isLoading={false}
+        onUrlChange={() => {}}
+        onSelectorsChange={onSelectorsChange}
+        onSubmit={() => {}}
+      />,
+    );
+    const selectorInput = screen.getByLabelText("CSS セレクタ 1");
+    await user.type(selectorInput, "h");
+    expect(onSelectorsChange).toHaveBeenLastCalledWith([{ name: "", selector: "h" }]);
+  });
+});

--- a/src/features/web-scraper/components/scraper-form.tsx
+++ b/src/features/web-scraper/components/scraper-form.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { Loader2, MousePointerClick, Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  MAX_SELECTORS,
+  type ScraperSelectorInput,
+} from "@/features/web-scraper/lib/types";
+
+type Props = {
+  url: string;
+  selectors: ScraperSelectorInput[];
+  isLoading: boolean;
+  onUrlChange: (url: string) => void;
+  onSelectorsChange: (selectors: ScraperSelectorInput[]) => void;
+  onSubmit: () => void;
+};
+
+export function ScraperForm({
+  url,
+  selectors,
+  isLoading,
+  onUrlChange,
+  onSelectorsChange,
+  onSubmit,
+}: Props) {
+  const hasSelectorEntered = selectors.some((s) => s.selector.trim().length > 0);
+  const canSubmit = url.trim().length > 0 && hasSelectorEntered && !isLoading;
+  const canAdd = selectors.length < MAX_SELECTORS;
+
+  const updateSelector = (index: number, patch: Partial<ScraperSelectorInput>) => {
+    const next = selectors.map((s, i) => (i === index ? { ...s, ...patch } : s));
+    onSelectorsChange(next);
+  };
+
+  const addSelector = () => {
+    if (!canAdd) return;
+    onSelectorsChange([...selectors, { name: "", selector: "" }]);
+  };
+
+  const removeSelector = (index: number) => {
+    if (selectors.length <= 1) return;
+    onSelectorsChange(selectors.filter((_, i) => i !== index));
+  };
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (canSubmit) onSubmit();
+      }}
+    >
+      <div className="space-y-2">
+        <Label htmlFor="scraper-url">URL</Label>
+        <Input
+          id="scraper-url"
+          type="url"
+          inputMode="url"
+          autoComplete="off"
+          placeholder="https://example.com"
+          value={url}
+          onChange={(e) => onUrlChange(e.target.value)}
+          disabled={isLoading}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label>CSS セレクタ</Label>
+        <div className="space-y-2">
+          {selectors.map((sel, index) => {
+            const nameId = `scraper-selector-name-${index}`;
+            const selectorId = `scraper-selector-${index}`;
+            return (
+              <div key={index} className="flex flex-col gap-2 sm:flex-row sm:items-start">
+                <div className="sm:w-40">
+                  <Label htmlFor={nameId} className="sr-only">
+                    ラベル {index + 1}
+                  </Label>
+                  <Input
+                    id={nameId}
+                    placeholder="ラベル（任意）"
+                    value={sel.name}
+                    onChange={(e) => updateSelector(index, { name: e.target.value })}
+                    disabled={isLoading}
+                  />
+                </div>
+                <div className="flex-1">
+                  <Label htmlFor={selectorId} className="sr-only">
+                    CSS セレクタ {index + 1}
+                  </Label>
+                  <Input
+                    id={selectorId}
+                    placeholder="例: h1, .article p, a[href]"
+                    value={sel.selector}
+                    onChange={(e) => updateSelector(index, { selector: e.target.value })}
+                    disabled={isLoading}
+                    className="font-mono"
+                  />
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => removeSelector(index)}
+                  disabled={isLoading || selectors.length <= 1}
+                  aria-label={`セレクタ ${index + 1} を削除`}
+                >
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+        <div className="flex items-center justify-between">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={addSelector}
+            disabled={isLoading || !canAdd}
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            セレクタを追加
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            最大 {MAX_SELECTORS} 件まで指定できます。
+          </p>
+        </div>
+      </div>
+
+      <div>
+        <Button type="submit" disabled={!canSubmit}>
+          {isLoading ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <MousePointerClick className="h-4 w-4" aria-hidden="true" />
+          )}
+          {isLoading ? "抽出中…" : "抽出する"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/features/web-scraper/components/scraper-result.tsx
+++ b/src/features/web-scraper/components/scraper-result.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { AlertCircle, Download } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { downloadCsv } from "@/lib/csv-export";
+import {
+  buildExportFilename,
+  downloadJson,
+  toScraperCsv,
+  toScraperJson,
+} from "@/features/web-scraper/lib/export";
+import {
+  MAX_MATCHES_PER_SELECTOR,
+  type ScraperResponse,
+  type SelectorResult,
+} from "@/features/web-scraper/lib/types";
+
+type Props = {
+  result: ScraperResponse | null;
+  isLoading: boolean;
+};
+
+export function ScraperResult({ result, isLoading }: Props) {
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">抽出中…</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-48 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!result) return null;
+
+  const totalMatches = result.results.reduce((sum, r) => sum + r.matches.length, 0);
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-4">
+        <div className="space-y-1">
+          <CardTitle className="text-base">抽出結果</CardTitle>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+            <span className="max-w-[420px] truncate font-mono" title={result.url}>
+              {result.url}
+            </span>
+            <span>マッチ合計: {totalMatches} 件</span>
+            <span>所要時間: {(result.durationMs / 1000).toFixed(1)} 秒</span>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => downloadJson(toScraperJson(result), buildExportFilename("json"))}
+            disabled={totalMatches === 0}
+          >
+            <Download className="h-4 w-4" aria-hidden="true" />
+            JSON
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => downloadCsv(toScraperCsv(result), buildExportFilename("csv"))}
+            disabled={totalMatches === 0}
+          >
+            <Download className="h-4 w-4" aria-hidden="true" />
+            CSV
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <Tabs key={`${result.url}-${result.durationMs}`} defaultValue="0">
+          <TabsList>
+            {result.results.map((r, index) => (
+              <TabsTrigger key={index} value={String(index)}>
+                {tabLabel(r)}
+                <Badge variant="secondary" className="ml-1">
+                  {r.matches.length}
+                </Badge>
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          {result.results.map((r, index) => (
+            <TabsContent key={index} value={String(index)} className="space-y-3">
+              <SelectorPanel result={r} />
+            </TabsContent>
+          ))}
+        </Tabs>
+      </CardContent>
+    </Card>
+  );
+}
+
+function tabLabel(result: SelectorResult): string {
+  const label = result.name.trim() || result.selector;
+  return label.length > 24 ? `${label.slice(0, 24)}…` : label;
+}
+
+function SelectorPanel({ result }: { result: SelectorResult }) {
+  if (result.error) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="h-4 w-4" aria-hidden="true" />
+        <AlertTitle>セレクタエラー</AlertTitle>
+        <AlertDescription>
+          <span className="font-mono">{result.selector}</span>: {result.error}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (result.matches.length === 0) {
+    return (
+      <p className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+        セレクタ <span className="font-mono">{result.selector}</span> にマッチする要素はありませんでした。
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground">
+        セレクタ: <span className="font-mono">{result.selector}</span>
+        {result.truncated && (
+          <Badge
+            variant="outline"
+            className="ml-2 border-amber-300 text-amber-900 dark:border-amber-800 dark:text-amber-200"
+          >
+            上限 {MAX_MATCHES_PER_SELECTOR} 件で切り捨て
+          </Badge>
+        )}
+      </p>
+      <div className="overflow-x-auto rounded-md border">
+        <table className="w-full text-xs">
+          <thead className="bg-muted/30">
+            <tr>
+              <th className="w-10 px-3 py-2 text-right font-medium">#</th>
+              <th className="px-3 py-2 text-left font-medium">テキスト</th>
+              <th className="px-3 py-2 text-left font-medium">href</th>
+              <th className="px-3 py-2 text-left font-medium">src</th>
+            </tr>
+          </thead>
+          <tbody>
+            {result.matches.map((match, index) => (
+              <tr key={index} className="border-t align-top">
+                <td className="px-3 py-1.5 text-right tabular-nums text-muted-foreground">
+                  {index}
+                </td>
+                <td className="max-w-[480px] px-3 py-1.5">
+                  <span className="line-clamp-3 whitespace-pre-wrap">
+                    {match.text || <span className="text-muted-foreground">（空）</span>}
+                  </span>
+                </td>
+                <td className="max-w-[260px] truncate px-3 py-1.5 font-mono">
+                  {match.href ? (
+                    <a
+                      href={match.href}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      title={match.href}
+                      className="hover:underline"
+                    >
+                      {match.href}
+                    </a>
+                  ) : (
+                    <span className="text-muted-foreground">-</span>
+                  )}
+                </td>
+                <td className="max-w-[260px] truncate px-3 py-1.5 font-mono" title={match.src}>
+                  {match.src ?? <span className="text-muted-foreground">-</span>}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/features/web-scraper/components/web-scraper-page.tsx
+++ b/src/features/web-scraper/components/web-scraper-page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { AlertCircle } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { scrape } from "@/features/web-scraper/lib/web-scraper-client";
+import type {
+  ScraperError,
+  ScraperResponse,
+  ScraperSelectorInput,
+} from "@/features/web-scraper/lib/types";
+import { ScraperForm } from "./scraper-form";
+import { ScraperResult } from "./scraper-result";
+
+const INITIAL_SELECTORS: ScraperSelectorInput[] = [{ name: "", selector: "" }];
+
+export function WebScraperPage() {
+  const [url, setUrl] = useState("");
+  const [selectors, setSelectors] = useState<ScraperSelectorInput[]>(INITIAL_SELECTORS);
+  const [result, setResult] = useState<ScraperResponse | null>(null);
+  const [error, setError] = useState<ScraperError | undefined>();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = useCallback(async () => {
+    if (isLoading) return;
+
+    const cleaned = selectors
+      .map((s) => ({ name: s.name.trim(), selector: s.selector.trim() }))
+      .filter((s) => s.selector.length > 0);
+
+    setIsLoading(true);
+    setResult(null);
+    setError(undefined);
+
+    const res = await scrape({ url: url.trim(), selectors: cleaned });
+    if (res.ok) {
+      setResult(res.data);
+    } else {
+      setError(res.error);
+    }
+    setIsLoading(false);
+  }, [isLoading, selectors, url]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Webスクレイピングツール</h1>
+        <p className="mt-2 text-muted-foreground">
+          URL と CSS セレクタを指定すると、サーバー側 Playwright がページを開いて該当要素を抽出します。
+          複数セレクタの同時抽出、テキスト・href・src の取得、JSON / CSV エクスポートに対応します。
+        </p>
+      </div>
+
+      <ScraperForm
+        url={url}
+        selectors={selectors}
+        isLoading={isLoading}
+        onUrlChange={setUrl}
+        onSelectorsChange={setSelectors}
+        onSubmit={handleSubmit}
+      />
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" aria-hidden="true" />
+          <AlertTitle>抽出に失敗しました</AlertTitle>
+          <AlertDescription>{error.error}</AlertDescription>
+        </Alert>
+      )}
+
+      <ScraperResult result={result} isLoading={isLoading} />
+    </div>
+  );
+}

--- a/src/features/web-scraper/lib/__tests__/export.test.ts
+++ b/src/features/web-scraper/lib/__tests__/export.test.ts
@@ -1,0 +1,139 @@
+import {
+  CSV_HEADERS,
+  buildExportFilename,
+  toScraperCsv,
+  toScraperJson,
+} from "../export";
+import type { ScraperResponse } from "../types";
+
+const baseResponse = (overrides: Partial<ScraperResponse> = {}): ScraperResponse => ({
+  url: "https://example.com",
+  durationMs: 1234,
+  results: [],
+  ...overrides,
+});
+
+describe("toScraperCsv", () => {
+  it("emits a header-only line when there are no matches", () => {
+    const csv = toScraperCsv(baseResponse());
+    expect(csv).toBe(CSV_HEADERS.join(","));
+  });
+
+  it("flattens multiple selectors into per-row records", () => {
+    const csv = toScraperCsv(
+      baseResponse({
+        results: [
+          {
+            name: "headings",
+            selector: "h1",
+            truncated: false,
+            matches: [{ text: "Hello", html: "Hello", href: undefined, src: undefined }],
+          },
+          {
+            name: "links",
+            selector: "a",
+            truncated: false,
+            matches: [
+              {
+                text: "Anchor",
+                html: "Anchor",
+                href: "https://example.com/x",
+                src: undefined,
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    const lines = csv.split("\r\n");
+    expect(lines[0]).toBe(CSV_HEADERS.join(","));
+    expect(lines[1]).toBe("headings,h1,0,Hello,Hello,,");
+    expect(lines[2]).toBe("links,a,0,Anchor,Anchor,https://example.com/x,");
+  });
+
+  it("escapes commas, quotes, and newlines in cell content", () => {
+    const csv = toScraperCsv(
+      baseResponse({
+        results: [
+          {
+            name: "p",
+            selector: "p",
+            truncated: false,
+            matches: [
+              {
+                text: 'has "quotes", commas, and\nnewlines',
+                html: "<b>x</b>",
+                href: undefined,
+                src: undefined,
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    const lines = csv.split("\r\n");
+    expect(lines[1]).toBe('p,p,0,"has ""quotes"", commas, and\nnewlines",<b>x</b>,,');
+  });
+
+  it("omits selectors with zero matches but retains others", () => {
+    const csv = toScraperCsv(
+      baseResponse({
+        results: [
+          { name: "empty", selector: ".gone", truncated: false, matches: [] },
+          {
+            name: "kept",
+            selector: "p",
+            truncated: false,
+            matches: [{ text: "x", html: "x", href: undefined, src: undefined }],
+          },
+        ],
+      }),
+    );
+    const lines = csv.split("\r\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toBe("kept,p,0,x,x,,");
+  });
+
+  it("includes index per match within a selector", () => {
+    const csv = toScraperCsv(
+      baseResponse({
+        results: [
+          {
+            name: "items",
+            selector: "li",
+            truncated: false,
+            matches: [
+              { text: "a", html: "a", href: undefined, src: undefined },
+              { text: "b", html: "b", href: undefined, src: undefined },
+              { text: "c", html: "c", href: undefined, src: undefined },
+            ],
+          },
+        ],
+      }),
+    );
+    const lines = csv.split("\r\n");
+    expect(lines[1]).toBe("items,li,0,a,a,,");
+    expect(lines[2]).toBe("items,li,1,b,b,,");
+    expect(lines[3]).toBe("items,li,2,c,c,,");
+  });
+});
+
+describe("toScraperJson", () => {
+  it("returns indented JSON of the response", () => {
+    const json = toScraperJson(baseResponse({ durationMs: 42 }));
+    const parsed = JSON.parse(json);
+    expect(parsed).toEqual({ url: "https://example.com", durationMs: 42, results: [] });
+    expect(json).toContain("\n  ");
+  });
+});
+
+describe("buildExportFilename", () => {
+  it("uses ISO timestamp with safe separators", () => {
+    const filename = buildExportFilename("csv");
+    expect(filename).toMatch(/^web-scrape-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.csv$/);
+  });
+
+  it("supports json extension", () => {
+    expect(buildExportFilename("json")).toMatch(/\.json$/);
+  });
+});

--- a/src/features/web-scraper/lib/export.ts
+++ b/src/features/web-scraper/lib/export.ts
@@ -1,0 +1,52 @@
+import { toCsv, type CsvCell } from "@/lib/csv-export";
+import type { ScraperResponse } from "@/features/web-scraper/lib/types";
+
+export const CSV_HEADERS = [
+  "selector_name",
+  "selector",
+  "index",
+  "text",
+  "html",
+  "href",
+  "src",
+] as const;
+
+export function toScraperCsv(response: ScraperResponse): string {
+  const rows: CsvCell[][] = [];
+  for (const result of response.results) {
+    if (result.matches.length === 0) continue;
+    result.matches.forEach((match, index) => {
+      rows.push([
+        result.name,
+        result.selector,
+        index,
+        match.text,
+        match.html,
+        match.href ?? "",
+        match.src ?? "",
+      ]);
+    });
+  }
+  return toCsv([...CSV_HEADERS], rows);
+}
+
+export function toScraperJson(response: ScraperResponse): string {
+  return JSON.stringify(response, null, 2);
+}
+
+export function downloadJson(content: string, filename: string): void {
+  const blob = new Blob([content], { type: "application/json;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export function buildExportFilename(extension: "json" | "csv"): string {
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return `web-scrape-${stamp}.${extension}`;
+}

--- a/src/features/web-scraper/lib/types.ts
+++ b/src/features/web-scraper/lib/types.ts
@@ -1,0 +1,45 @@
+export const MAX_SELECTORS = 10;
+export const MAX_MATCHES_PER_SELECTOR = 200;
+export const NAVIGATION_TIMEOUT_MS = 20_000;
+
+export type ScraperSelectorInput = {
+  name: string;
+  selector: string;
+};
+
+export type ScrapedElement = {
+  text: string;
+  html: string;
+  href?: string;
+  src?: string;
+};
+
+export type SelectorResult = {
+  name: string;
+  selector: string;
+  matches: ScrapedElement[];
+  truncated: boolean;
+  error?: string;
+};
+
+export type ScraperOptions = {
+  url: string;
+  selectors: ScraperSelectorInput[];
+};
+
+export type ScraperResponse = {
+  url: string;
+  results: SelectorResult[];
+  durationMs: number;
+};
+
+export type ScraperError = {
+  error: string;
+  errorCode: string;
+};
+
+export function isSelectorInput(value: unknown): value is ScraperSelectorInput {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.name === "string" && typeof v.selector === "string";
+}

--- a/src/features/web-scraper/lib/web-scraper-client.ts
+++ b/src/features/web-scraper/lib/web-scraper-client.ts
@@ -1,0 +1,59 @@
+import type {
+  ScraperError,
+  ScraperOptions,
+  ScraperResponse,
+} from "@/features/web-scraper/lib/types";
+
+export type ScrapeResult =
+  | { ok: true; data: ScraperResponse }
+  | { ok: false; error: ScraperError; status: number };
+
+export async function scrape(
+  options: ScraperOptions,
+  signal?: AbortSignal,
+): Promise<ScrapeResult> {
+  let response: Response;
+  try {
+    response = await fetch("/api/web-scraper", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(options),
+      signal,
+    });
+  } catch (e) {
+    const aborted = e instanceof DOMException && e.name === "AbortError";
+    return {
+      ok: false,
+      status: 0,
+      error: {
+        error: aborted ? "リクエストが中断されました。" : "サーバーに接続できませんでした。",
+        errorCode: aborted ? "ABORTED" : "NETWORK_ERROR",
+      },
+    };
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    return {
+      ok: false,
+      status: response.status,
+      error: { error: "サーバーからの応答を解析できませんでした。", errorCode: "PARSE_ERROR" },
+    };
+  }
+
+  if (!response.ok) {
+    const err = payload as Partial<ScraperError>;
+    return {
+      ok: false,
+      status: response.status,
+      error: {
+        error: err.error ?? `エラー (${response.status})`,
+        errorCode: err.errorCode ?? "UNKNOWN_ERROR",
+      },
+    };
+  }
+
+  return { ok: true, data: payload as ScraperResponse };
+}


### PR DESCRIPTION
## Summary
- URLとCSSセレクタを指定してサーバー側 Playwright で要素を抽出する新ツール `/tools/web-scraper` を追加
- 複数CSSセレクタの同時抽出に対応（最大10件、1セレクタあたり最大200マッチ）
- 抽出データはテキスト・innerHTML・href（`<a>`）・src（`<img>`）。タブ切り替えのテーブル UI でセレクタごとの結果を表示
- JSON / CSV エクスポート（CSV は既存の `src/lib/csv-export.ts` を再利用、UTF-8 BOM 付き）
- レート制限・SSRF ガード・ナビゲーションタイムアウトは既存ユーティリティ（`createRateLimit` / `validateRequestUrl`）を再利用
- ページネーション・要素ハイライトプレビュー・XPath サポート・robots.txt 尊重は別Issueに分離（v1スコープ外）

Closes #43

## Test plan
- [ ] `npm run lint` 通過
- [ ] `npm run test` 通過（684 / 684 passed、新規 `export.test.ts` と `scraper-form.test.tsx` を含む）
- [ ] `npm run build` 通過
- [ ] `npm run dev` で `http://localhost:3000/tools/web-scraper` を開き、`https://example.com` + セレクタ `h1, p` で抽出結果がテーブル表示される
- [ ] 複数セレクタ（例: `h1` と `a`）を追加し、それぞれ別タブで結果が表示される
- [ ] 無効なセレクタ（例: `>>>invalid<<<`）で当該タブのみエラー表示、他のセレクタは成功する
- [ ] localhost / プライベートIP の URL を入力するとブロックされエラーが表示される
- [ ] JSON ダウンロードで `web-scrape-<timestamp>.json` が保存される
- [ ] CSV ダウンロードで Excel が文字化けせず開ける
- [ ] 6回連続で送信すると6回目に 429 が返る（IPベースのレート制限）

## サイズ
11 files / +1016 / -1 行。共有規約のサイズ上限（10ファイル / 300行）を超えるが、本PRは新ツールのスキャフォールド追加が中心であり new-feature 例外が適用される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)