### PR TITLE
feat: GitHub Repo Analyzer にコントリビューションヒートマップを追加

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,8 @@
 # Google AI (Gemini) — required for Text Rewriter
 # Get your API key at https://aistudio.google.com/apikey
 GEMINI_API_KEY=your_api_key_here
+
+# GitHub Personal Access Token — required for GitHub Repo Analyzer contribution heatmap
+# Create one at https://github.com/settings/tokens (classic, scope: read:user)
+# If unset, the heatmap is disabled but other features (repo list, language, issues/PRs) still work.
+GITHUB_TOKEN=your_github_token_here

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ cp .env.local.example .env.local
 npm run dev
 ```
 
+### Environment Variables
+
+- `GEMINI_API_KEY` — required for **Text Rewriter**. Get one at https://aistudio.google.com/apikey.
+- `GITHUB_TOKEN` — optional, enables the contribution heatmap in **GitHub Repo Analyzer**. Create a classic Personal Access Token with the `read:user` scope at https://github.com/settings/tokens. If unset, the heatmap is shown as disabled and other features still work.
+
 ## Claude Code Setup
 
 This project syncs shared Claude Code configuration from [shared-claude-code](https://github.com/tatsushige-i/shared-claude-code).

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -26,6 +26,11 @@ cp .env.local.example .env.local
 npm run dev
 ```
 
+### 環境変数
+
+- `GEMINI_API_KEY` — **Text Rewriter** で必須。https://aistudio.google.com/apikey で取得。
+- `GITHUB_TOKEN` — 任意。**GitHub Repo Analyzer** のコントリビューションヒートマップを有効化します。https://github.com/settings/tokens で classic Personal Access Token を `read:user` スコープのみで発行してください。未設定時はヒートマップのみグレーアウトされ、その他の機能はそのまま動作します。
+
 ## Claude Code セットアップ
 
 このプロジェクトは [shared-claude-code](https://github.com/tatsushige-i/shared-claude-code) から Claude Code の共有設定を同期して利用しています。

--- a/src/app/api/github/route.ts
+++ b/src/app/api/github/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { createRateLimit } from "@/lib/rate-limit";
 import { getClientIp, rateLimitResponse } from "@/lib/api-helpers";
 import type {
+  ContributionCalendar,
+  ContributionLevel,
   LanguageBreakdown,
   RepoStats,
   RepoSummary,
@@ -35,8 +37,11 @@ export async function GET(request: Request) {
   if (mode === "repo-stats") {
     return handleRepoStats(searchParams);
   }
+  if (mode === "contributions") {
+    return handleContributions(searchParams);
+  }
   return validationError(
-    "mode は repos / repo-stats のいずれかを指定してください。"
+    "mode は repos / repo-stats / contributions のいずれかを指定してください。"
   );
 }
 
@@ -247,4 +252,158 @@ type GithubRepoResponse = {
 
 type GithubSearchResponse = {
   total_count?: number;
+};
+
+const CONTRIBUTIONS_QUERY = `query($login: String!) {
+  user(login: $login) {
+    contributionsCollection {
+      contributionCalendar {
+        totalContributions
+        weeks {
+          contributionDays {
+            date
+            contributionCount
+            contributionLevel
+          }
+        }
+      }
+    }
+  }
+}`;
+
+async function handleContributions(params: URLSearchParams): Promise<Response> {
+  const username = params.get("username") ?? "";
+  if (!USERNAME_PATTERN.test(username)) {
+    return validationError(
+      "username は1〜39文字の英数字とハイフンで指定してください。"
+    );
+  }
+
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    return NextResponse.json(
+      {
+        error:
+          "GITHUB_TOKEN が設定されていません。.env.local に設定してください。",
+        errorCode: "NO_AUTH_TOKEN",
+      },
+      { status: 503 }
+    );
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${GITHUB_API_BASE}/graphql`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+        "User-Agent": USER_AGENT,
+      },
+      body: JSON.stringify({
+        query: CONTRIBUTIONS_QUERY,
+        variables: { login: username },
+      }),
+    });
+  } catch {
+    return NextResponse.json(
+      {
+        error: "GitHub に接続できませんでした。",
+        errorCode: "UPSTREAM_ERROR",
+      },
+      { status: 502 }
+    );
+  }
+
+  if (upstream.status === 401) {
+    return NextResponse.json(
+      {
+        error:
+          "GITHUB_TOKEN が無効です。.env.local に有効なトークンを設定してください。",
+        errorCode: "INVALID_TOKEN",
+      },
+      { status: 401 }
+    );
+  }
+  if (!upstream.ok) {
+    return NextResponse.json(
+      {
+        error: "コントリビューション情報の取得に失敗しました。",
+        errorCode: "UPSTREAM_ERROR",
+      },
+      { status: 502 }
+    );
+  }
+
+  const payload = (await upstream.json()) as GraphQLContributionsResponse;
+
+  const notFound = payload.errors?.some((e) => e.type === "NOT_FOUND");
+  if (notFound || !payload.data?.user) {
+    return NextResponse.json(
+      {
+        error: "指定されたユーザーが見つかりませんでした。",
+        errorCode: "NOT_FOUND",
+      },
+      { status: 404 }
+    );
+  }
+
+  if (payload.errors && payload.errors.length > 0) {
+    return NextResponse.json(
+      {
+        error: "コントリビューション情報の取得に失敗しました。",
+        errorCode: "UPSTREAM_ERROR",
+      },
+      { status: 502 }
+    );
+  }
+
+  const calendar =
+    payload.data.user.contributionsCollection.contributionCalendar;
+  const result: ContributionCalendar = {
+    totalContributions: calendar.totalContributions,
+    weeks: calendar.weeks.map((w) => ({
+      days: w.contributionDays.map((d) => ({
+        date: d.date,
+        count: d.contributionCount,
+        level: toContributionLevel(d.contributionLevel),
+      })),
+    })),
+  };
+  return NextResponse.json(result);
+}
+
+function toContributionLevel(level: string): ContributionLevel {
+  switch (level) {
+    case "FIRST_QUARTILE":
+      return 1;
+    case "SECOND_QUARTILE":
+      return 2;
+    case "THIRD_QUARTILE":
+      return 3;
+    case "FOURTH_QUARTILE":
+      return 4;
+    default:
+      return 0;
+  }
+}
+
+type GraphQLContributionsResponse = {
+  data?: {
+    user: {
+      contributionsCollection: {
+        contributionCalendar: {
+          totalContributions: number;
+          weeks: {
+            contributionDays: {
+              date: string;
+              contributionCount: number;
+              contributionLevel: string;
+            }[];
+          }[];
+        };
+      };
+    } | null;
+  };
+  errors?: { type?: string; message?: string }[];
 };

--- a/src/app/api/github/route.ts
+++ b/src/app/api/github/route.ts
@@ -325,6 +325,19 @@ async function handleContributions(params: URLSearchParams): Promise<Response> {
       { status: 401 }
     );
   }
+  if (
+    upstream.status === 403 &&
+    upstream.headers.get("X-RateLimit-Remaining") === "0"
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          "GitHub API のレート制限に達しました。しばらく経ってから再度お試しください。",
+        errorCode: "RATE_LIMITED",
+      },
+      { status: 429 }
+    );
+  }
   if (!upstream.ok) {
     return NextResponse.json(
       {

--- a/src/features/github-repo-analyzer/components/contribution-heatmap.tsx
+++ b/src/features/github-repo-analyzer/components/contribution-heatmap.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useState, type MouseEvent as ReactMouseEvent } from "react";
+import { AlertCircle, Info } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useContributionCalendar } from "../lib/use-contribution-calendar";
+import type {
+  ContributionCalendar,
+  ContributionDay,
+  ContributionLevel,
+} from "../lib/types";
+
+const CELL_SIZE = 12;
+const CELL_GAP = 3;
+const STEP = CELL_SIZE + CELL_GAP;
+const PLACEHOLDER_WEEKS = 53;
+const DAYS_PER_WEEK = 7;
+const AXIS_LEFT = 28;
+const AXIS_TOP = 20;
+const AXIS_RIGHT = 24;
+const AXIS_FONT_SIZE = 10;
+const DAY_OF_WEEK_LABELS: Record<number, string> = {
+  1: "月",
+  3: "水",
+  5: "金",
+};
+
+const LEVEL_FILL: Record<ContributionLevel, string> = {
+  0: "fill-muted",
+  1: "fill-emerald-200 dark:fill-emerald-900",
+  2: "fill-emerald-400 dark:fill-emerald-700",
+  3: "fill-emerald-600 dark:fill-emerald-500",
+  4: "fill-emerald-800 dark:fill-emerald-300",
+};
+
+type Props = {
+  username: string;
+};
+
+export function ContributionHeatmap({ username }: Props) {
+  const { calendar, error, loading } = useContributionCalendar(username);
+
+  if (!username) return null;
+
+  const isNoToken = error?.errorCode === "NO_AUTH_TOKEN";
+  const isOtherError = error && !isNoToken;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>コントリビューション</CardTitle>
+        <CardDescription>
+          {calendar
+            ? `直近1年で ${calendar.totalContributions.toLocaleString()} コントリビューション`
+            : "GitHub プロフィールと同様の 52週 × 7日のヒートマップを表示します。"}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {loading && (
+          <Skeleton
+            className="w-full"
+            style={{ height: DAYS_PER_WEEK * STEP - CELL_GAP }}
+          />
+        )}
+
+        {isNoToken && (
+          <div className="space-y-3">
+            <div
+              aria-hidden="true"
+              className="overflow-x-auto opacity-30 grayscale"
+            >
+              <PlaceholderGrid />
+            </div>
+            <Alert role="status">
+              <Info className="size-4" />
+              <AlertTitle>GITHUB_TOKEN が未設定です</AlertTitle>
+              <AlertDescription>
+                ヒートマップを表示するには <code>.env.local</code> に{" "}
+                <code>GITHUB_TOKEN</code> を設定してください。リポジトリ一覧などの既存機能はそのまま利用できます。
+              </AlertDescription>
+            </Alert>
+          </div>
+        )}
+
+        {isOtherError && (
+          <Alert variant="destructive" role="alert">
+            <AlertCircle className="size-4" />
+            <AlertTitle>コントリビューションの取得に失敗しました</AlertTitle>
+            <AlertDescription>{error.message}</AlertDescription>
+          </Alert>
+        )}
+
+        {calendar && <CalendarGrid calendar={calendar} />}
+      </CardContent>
+    </Card>
+  );
+}
+
+function CalendarGrid({ calendar }: { calendar: ContributionCalendar }) {
+  const weeks = calendar.weeks;
+  const width = AXIS_LEFT + weeks.length * STEP - CELL_GAP + AXIS_RIGHT;
+  const height = AXIS_TOP + DAYS_PER_WEEK * STEP - CELL_GAP;
+  const monthLabels = computeMonthLabels(calendar);
+
+  const [tooltip, setTooltip] = useState<{
+    text: string;
+    x: number;
+    y: number;
+  } | null>(null);
+
+  const showTooltip = (
+    e: ReactMouseEvent<SVGRectElement>,
+    day: ContributionDay
+  ) => {
+    setTooltip({
+      text: `${day.date}: ${day.count.toLocaleString()} contributions`,
+      x: e.clientX,
+      y: e.clientY,
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="overflow-x-auto">
+        <svg
+          role="img"
+          aria-label={`${calendar.totalContributions} contributions in the last year`}
+          width={width}
+          height={height}
+          viewBox={`0 0 ${width} ${height}`}
+          className="block"
+        >
+          {monthLabels.map((m) => (
+            <text
+              key={`month-${m.weekIndex}`}
+              x={AXIS_LEFT + m.weekIndex * STEP}
+              y={AXIS_TOP - 6}
+              fontSize={AXIS_FONT_SIZE}
+              className="fill-muted-foreground"
+            >
+              {m.label}
+            </text>
+          ))}
+
+          {Object.entries(DAY_OF_WEEK_LABELS).map(([dayIndex, label]) => (
+            <text
+              key={`day-${dayIndex}`}
+              x={AXIS_LEFT - 4}
+              y={
+                AXIS_TOP + Number(dayIndex) * STEP + CELL_SIZE - 2
+              }
+              fontSize={AXIS_FONT_SIZE}
+              textAnchor="end"
+              className="fill-muted-foreground"
+            >
+              {label}
+            </text>
+          ))}
+
+          {weeks.map((week, weekIndex) =>
+            week.days.map((day, dayIndex) => (
+              <rect
+                key={`${weekIndex}-${dayIndex}`}
+                x={AXIS_LEFT + weekIndex * STEP}
+                y={AXIS_TOP + dayIndex * STEP}
+                width={CELL_SIZE}
+                height={CELL_SIZE}
+                rx={2}
+                ry={2}
+                className={LEVEL_FILL[day.level]}
+                onMouseEnter={(e) => showTooltip(e, day)}
+                onMouseMove={(e) => showTooltip(e, day)}
+                onMouseLeave={() => setTooltip(null)}
+              />
+            ))
+          )}
+        </svg>
+      </div>
+      <Legend />
+      {tooltip && (
+        <div
+          role="tooltip"
+          className="pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded-md border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md"
+          style={{
+            left: tooltip.x,
+            top: tooltip.y - 8,
+          }}
+        >
+          {tooltip.text}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function computeMonthLabels(
+  calendar: ContributionCalendar
+): { weekIndex: number; label: string }[] {
+  const labels: { weekIndex: number; label: string }[] = [];
+  let lastMonth = -1;
+  calendar.weeks.forEach((week, weekIndex) => {
+    const firstDay = week.days[0];
+    if (!firstDay) return;
+    const month = new Date(firstDay.date).getMonth();
+    if (month !== lastMonth) {
+      lastMonth = month;
+      labels.push({ weekIndex, label: `${month + 1}月` });
+    }
+  });
+  // Drop the first label if it would overlap the y-axis (typically week 0)
+  // and the second label is close — keeps the axis readable.
+  if (labels.length >= 2 && labels[1].weekIndex - labels[0].weekIndex < 3) {
+    labels.shift();
+  }
+  return labels;
+}
+
+function Legend() {
+  const levels: ContributionLevel[] = [0, 1, 2, 3, 4];
+  const legendCell = 10;
+  const legendGap = 2;
+  const legendWidth = levels.length * (legendCell + legendGap) - legendGap;
+
+  return (
+    <div className="flex items-center justify-end gap-2 text-xs text-muted-foreground">
+      <span>少ない</span>
+      <svg
+        aria-hidden="true"
+        width={legendWidth}
+        height={legendCell}
+        viewBox={`0 0 ${legendWidth} ${legendCell}`}
+        className="block"
+      >
+        {levels.map((level, i) => (
+          <rect
+            key={level}
+            x={i * (legendCell + legendGap)}
+            y={0}
+            width={legendCell}
+            height={legendCell}
+            rx={2}
+            ry={2}
+            className={LEVEL_FILL[level]}
+          />
+        ))}
+      </svg>
+      <span>多い</span>
+    </div>
+  );
+}
+
+function PlaceholderGrid() {
+  const width = PLACEHOLDER_WEEKS * STEP - CELL_GAP;
+  const height = DAYS_PER_WEEK * STEP - CELL_GAP;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className="block"
+    >
+      {Array.from({ length: PLACEHOLDER_WEEKS }).map((_, weekIndex) =>
+        Array.from({ length: DAYS_PER_WEEK }).map((_, dayIndex) => (
+          <rect
+            key={`${weekIndex}-${dayIndex}`}
+            x={weekIndex * STEP}
+            y={dayIndex * STEP}
+            width={CELL_SIZE}
+            height={CELL_SIZE}
+            rx={2}
+            ry={2}
+            className="fill-muted"
+          />
+        ))
+      )}
+    </svg>
+  );
+}

--- a/src/features/github-repo-analyzer/components/contribution-heatmap.tsx
+++ b/src/features/github-repo-analyzer/components/contribution-heatmap.tsx
@@ -209,7 +209,7 @@ function computeMonthLabels(
   calendar.weeks.forEach((week, weekIndex) => {
     const firstDay = week.days[0];
     if (!firstDay) return;
-    const month = new Date(firstDay.date).getMonth();
+    const month = new Date(firstDay.date).getUTCMonth();
     if (month !== lastMonth) {
       lastMonth = month;
       labels.push({ weekIndex, label: `${month + 1}月` });

--- a/src/features/github-repo-analyzer/components/github-repo-analyzer-page.tsx
+++ b/src/features/github-repo-analyzer/components/github-repo-analyzer-page.tsx
@@ -5,6 +5,7 @@ import { AlertCircle } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useGithubRepos } from "../lib/use-github-repos";
 import type { RepoSummary, SortKey } from "../lib/types";
+import { ContributionHeatmap } from "./contribution-heatmap";
 import { RepoDetailPanel } from "./repo-detail-panel";
 import { RepoList } from "./repo-list";
 import { UsernameSearchForm } from "./username-search-form";
@@ -33,6 +34,8 @@ export function GithubRepoAnalyzerPage() {
       </div>
 
       <UsernameSearchForm onSubmit={handleSubmit} />
+
+      {username && <ContributionHeatmap username={username} />}
 
       {error && (
         <Alert variant="destructive" role="alert">

--- a/src/features/github-repo-analyzer/components/username-search-form.tsx
+++ b/src/features/github-repo-analyzer/components/username-search-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type FormEvent } from "react";
+import { useState, type FormEvent, type KeyboardEvent } from "react";
 import { Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -14,11 +14,22 @@ type Props = {
 export function UsernameSearchForm({ onSubmit, initialValue = "" }: Props) {
   const [value, setValue] = useState(initialValue);
 
-  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const submit = () => {
     const trimmed = value.trim();
     if (!trimmed) return;
     onSubmit(trimmed);
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    submit();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "Enter") return;
+    if (e.nativeEvent.isComposing) return;
+    e.preventDefault();
+    submit();
   };
 
   return (
@@ -33,6 +44,7 @@ export function UsernameSearchForm({ onSubmit, initialValue = "" }: Props) {
           type="text"
           value={value}
           onChange={(e) => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
           placeholder="例: facebook"
           autoComplete="off"
           spellCheck={false}

--- a/src/features/github-repo-analyzer/lib/__tests__/github-client.test.ts
+++ b/src/features/github-repo-analyzer/lib/__tests__/github-client.test.ts
@@ -1,5 +1,6 @@
 import {
   GithubApiError,
+  fetchContributionCalendar,
   fetchRepoStats,
   fetchUserRepos,
 } from "../github-client";
@@ -143,6 +144,96 @@ describe("fetchRepoStats", () => {
     });
 
     const error = await fetchRepoStats("facebook", "nope").catch(
+      (e: unknown) => e
+    );
+    expect(error).toBeInstanceOf(GithubApiError);
+    expect((error as GithubApiError).errorCode).toBe("NOT_FOUND");
+  });
+});
+
+describe("fetchContributionCalendar", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("returns calendar on success", async () => {
+    const payload = {
+      totalContributions: 1234,
+      weeks: [
+        {
+          days: [
+            { date: "2025-05-05", count: 0, level: 0 },
+            { date: "2025-05-06", count: 5, level: 2 },
+          ],
+        },
+      ],
+    };
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(payload),
+    });
+    global.fetch = fetchMock;
+
+    const result = await fetchContributionCalendar("octocat");
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("mode=contributions")
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("username=octocat")
+    );
+  });
+
+  it("propagates NO_AUTH_TOKEN errorCode when token is unset", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: () =>
+        Promise.resolve({
+          error: "GITHUB_TOKEN が設定されていません。",
+          errorCode: "NO_AUTH_TOKEN",
+        }),
+    });
+
+    const error = await fetchContributionCalendar("octocat").catch(
+      (e: unknown) => e
+    );
+    expect(error).toBeInstanceOf(GithubApiError);
+    expect((error as GithubApiError).errorCode).toBe("NO_AUTH_TOKEN");
+  });
+
+  it("propagates INVALID_TOKEN errorCode on 401", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: () =>
+        Promise.resolve({
+          error: "GITHUB_TOKEN が無効です。",
+          errorCode: "INVALID_TOKEN",
+        }),
+    });
+
+    const error = await fetchContributionCalendar("octocat").catch(
+      (e: unknown) => e
+    );
+    expect(error).toBeInstanceOf(GithubApiError);
+    expect((error as GithubApiError).errorCode).toBe("INVALID_TOKEN");
+  });
+
+  it("propagates NOT_FOUND errorCode for unknown user", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: () =>
+        Promise.resolve({
+          error: "指定されたユーザーが見つかりませんでした。",
+          errorCode: "NOT_FOUND",
+        }),
+    });
+
+    const error = await fetchContributionCalendar("nope-such-user").catch(
       (e: unknown) => e
     );
     expect(error).toBeInstanceOf(GithubApiError);

--- a/src/features/github-repo-analyzer/lib/github-client.ts
+++ b/src/features/github-repo-analyzer/lib/github-client.ts
@@ -1,5 +1,6 @@
 import type {
   ApiErrorCode,
+  ContributionCalendar,
   RepoStats,
   RepoSummary,
   SortKey,
@@ -50,4 +51,14 @@ export function fetchRepoStats(
     repo,
   });
   return request<RepoStats>(`/api/github?${params.toString()}`);
+}
+
+export function fetchContributionCalendar(
+  username: string
+): Promise<ContributionCalendar> {
+  const params = new URLSearchParams({
+    mode: "contributions",
+    username,
+  });
+  return request<ContributionCalendar>(`/api/github?${params.toString()}`);
 }

--- a/src/features/github-repo-analyzer/lib/types.ts
+++ b/src/features/github-repo-analyzer/lib/types.ts
@@ -3,7 +3,26 @@ export type ApiErrorCode =
   | "RATE_LIMITED"
   | "NOT_FOUND"
   | "UPSTREAM_ERROR"
-  | "SERVER_ERROR";
+  | "SERVER_ERROR"
+  | "NO_AUTH_TOKEN"
+  | "INVALID_TOKEN";
+
+export type ContributionLevel = 0 | 1 | 2 | 3 | 4;
+
+export type ContributionDay = {
+  date: string;
+  count: number;
+  level: ContributionLevel;
+};
+
+export type ContributionWeek = {
+  days: ContributionDay[];
+};
+
+export type ContributionCalendar = {
+  totalContributions: number;
+  weeks: ContributionWeek[];
+};
 
 export type RepoSummary = {
   id: number;

--- a/src/features/github-repo-analyzer/lib/use-contribution-calendar.ts
+++ b/src/features/github-repo-analyzer/lib/use-contribution-calendar.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { GithubApiError, fetchContributionCalendar } from "./github-client";
+import type { ApiErrorCode, ContributionCalendar } from "./types";
+
+type ErrorState = {
+  message: string;
+  errorCode?: ApiErrorCode;
+};
+
+function toErrorState(e: unknown): ErrorState {
+  if (e instanceof GithubApiError) {
+    return { message: e.message, errorCode: e.errorCode };
+  }
+  return {
+    message:
+      e instanceof Error
+        ? e.message
+        : "コントリビューション情報の取得に失敗しました。",
+  };
+}
+
+export function useContributionCalendar(username: string) {
+  const key = username;
+  const [result, setResult] = useState<
+    { data: ContributionCalendar; key: string } | null
+  >(null);
+  const [errorState, setErrorState] = useState<
+    { error: ErrorState; key: string } | null
+  >(null);
+
+  useEffect(() => {
+    if (!username) return;
+    let cancelled = false;
+    fetchContributionCalendar(username)
+      .then((calendar) => {
+        if (cancelled) return;
+        setResult({ data: calendar, key });
+        setErrorState(null);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setErrorState({ error: toErrorState(e), key });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [username, key]);
+
+  const calendar = result && result.key === key ? result.data : null;
+  const error =
+    errorState && errorState.key === key ? errorState.error : null;
+  const loading = username !== "" && calendar === null && error === null;
+
+  return { calendar, error, loading };
+}


### PR DESCRIPTION
## Summary

- `/api/github` に `mode=contributions` ハンドラを追加し、GitHub GraphQL API でコントリビューションカレンダーを取得
- `ContributionHeatmap` コンポーネントを新規追加（53週×7日 SVG、月軸・曜日軸・凡例・カスタムツールチップ）
- `GITHUB_TOKEN` 未設定時はヒートマップのみグレーアウトし、既存機能（リポジトリ一覧／言語比率／Issue・PR 数）はそのまま動作
- 検索フォームを IME 確定の Enter と区別して送信するよう改善
- README / `.env.local.example` に `GITHUB_TOKEN` のセットアップ手順を追記

Closes #185

## Test plan

- [ ] `GITHUB_TOKEN` 未設定で `/tools/github-repo-analyzer` にアクセスし、ヒートマップがグレーアウト + 注意文表示・既存機能が正常動作することを確認
- [ ] `GITHUB_TOKEN` を `.env.local` に設定して dev サーバー再起動後、自分の username で 53週×7日のヒートマップが描画されることを確認
- [ ] セルにマウスを乗せると `YYYY-MM-DD: N contributions` のツールチップが即座に表示されることを確認
- [ ] 月軸・曜日軸（月/水/金）が SVG 内に正しく表示され、見切れがないことを確認
- [ ] 検索フォームで日本語入力中の Enter（IME 確定）では送信されず、確定後の Enter で送信されることを確認
- [ ] 無効なトークンでは `INVALID_TOKEN` エラー、存在しないユーザーでは `NOT_FOUND` エラーが表示されることを確認
- [ ] `npm run lint` / `npm run test` / `npm run build` がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)