### PR TITLE
docs: GEMINI_API_KEY の説明に JSON Formatter を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm run dev
 
 ### Environment Variables
 
-- `GEMINI_API_KEY` — required for **Text Rewriter**. Get one at https://aistudio.google.com/apikey.
+- `GEMINI_API_KEY` — required for **Text Rewriter** and **JSON Formatter** (AI conversion). Get one at https://aistudio.google.com/apikey.
 - `GITHUB_TOKEN` — optional, enables the contribution heatmap in **GitHub Repo Analyzer**. Create a classic Personal Access Token with the `read:user` scope at https://github.com/settings/tokens. If unset, the heatmap is shown as disabled and other features still work.
 
 ## Claude Code Setup

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -28,7 +28,7 @@ npm run dev
 
 ### 環境変数
 
-- `GEMINI_API_KEY` — **Text Rewriter** で必須。https://aistudio.google.com/apikey で取得。
+- `GEMINI_API_KEY` — **Text Rewriter** と **JSON Formatter** (AI 変換) で必須。https://aistudio.google.com/apikey で取得。
 - `GITHUB_TOKEN` — 任意。**GitHub Repo Analyzer** のコントリビューションヒートマップを有効化します。https://github.com/settings/tokens で classic Personal Access Token を `read:user` スコープのみで発行してください。未設定時はヒートマップのみグレーアウトされ、その他の機能はそのまま動作します。
 
 ## Claude Code セットアップ


### PR DESCRIPTION
## Summary
- `README.md` と `docs/ja-JP/README.md` の `GEMINI_API_KEY` 行を更新し、**Text Rewriter** に加え **JSON Formatter** (AI 変換) でも必須であることを明記
- `.env.local.example` の既存記載 (`Text Rewriter and JSON Formatter (AI 変換)`) と整合

Closes #206

## Test plan
- [ ] `README.md` の該当行が「**Text Rewriter** and **JSON Formatter** (AI conversion)」に更新されていること
- [ ] `docs/ja-JP/README.md` の該当行が「**Text Rewriter** と **JSON Formatter** (AI 変換)」に更新されていること
- [ ] `.env.local.example` の記載と矛盾がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)