### PR TITLE
feat: GitHub Repo Analyzer に Issue/PR の平均クローズ時間表示を追加

### DIFF
--- a/src/app/api/github/route.ts
+++ b/src/app/api/github/route.ts
@@ -166,7 +166,6 @@ async function handleCloseTimeStats(
     url,
     "クローズ時間統計の取得に失敗しました。",
     {
-      token: process.env.GITHUB_TOKEN,
       revalidate: CLOSE_TIME_REVALIDATE_SECONDS,
     }
   );

--- a/src/app/api/github/route.ts
+++ b/src/app/api/github/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { createRateLimit } from "@/lib/rate-limit";
 import { getClientIp, rateLimitResponse } from "@/lib/api-helpers";
 import type {
+  CloseTimeStats,
   ContributionCalendar,
   ContributionLevel,
   LanguageBreakdown,
@@ -9,6 +10,7 @@ import type {
   RepoSummary,
   SortKey,
 } from "@/features/github-repo-analyzer/lib/types";
+import { computeCloseTimeMetric } from "@/features/github-repo-analyzer/lib/close-time-stats";
 
 const GITHUB_API_BASE = "https://api.github.com";
 const USER_AGENT = "personal-tools";
@@ -40,8 +42,11 @@ export async function GET(request: Request) {
   if (mode === "contributions") {
     return handleContributions(searchParams);
   }
+  if (mode === "close-time-stats") {
+    return handleCloseTimeStats(searchParams);
+  }
   return validationError(
-    "mode は repos / repo-stats / contributions のいずれかを指定してください。"
+    "mode は repos / repo-stats / contributions / close-time-stats のいずれかを指定してください。"
   );
 }
 
@@ -131,23 +136,105 @@ async function handleRepoStats(params: URLSearchParams): Promise<Response> {
   return NextResponse.json(stats);
 }
 
+const CLOSE_TIME_PER_PAGE = 100;
+const CLOSE_TIME_REVALIDATE_SECONDS = 3600;
+
+async function handleCloseTimeStats(
+  params: URLSearchParams
+): Promise<Response> {
+  const owner = params.get("owner") ?? "";
+  const repo = params.get("repo") ?? "";
+
+  if (!USERNAME_PATTERN.test(owner)) {
+    return validationError(
+      "owner は1〜39文字の英数字とハイフンで指定してください。"
+    );
+  }
+  if (!REPO_NAME_PATTERN.test(repo)) {
+    return validationError(
+      "repo は1〜100文字の英数字・ドット・アンダースコア・ハイフンで指定してください。"
+    );
+  }
+
+  const url = new URL(`${GITHUB_API_BASE}/repos/${owner}/${repo}/issues`);
+  url.searchParams.set("state", "closed");
+  url.searchParams.set("per_page", String(CLOSE_TIME_PER_PAGE));
+  url.searchParams.set("sort", "updated");
+  url.searchParams.set("direction", "desc");
+
+  const result = await fetchUpstream(
+    url,
+    "クローズ時間統計の取得に失敗しました。",
+    {
+      token: process.env.GITHUB_TOKEN,
+      revalidate: CLOSE_TIME_REVALIDATE_SECONDS,
+    }
+  );
+  if (!result.ok) return result.errorResponse;
+
+  const items = (await result.response.json()) as GithubIssueResponse[];
+  const issueDurations: number[] = [];
+  const prDurations: number[] = [];
+  for (const item of items) {
+    const duration = computeDurationMs(item.created_at, item.closed_at);
+    if (duration === null) continue;
+    if (item.pull_request) {
+      prDurations.push(duration);
+    } else {
+      issueDurations.push(duration);
+    }
+  }
+
+  const stats: CloseTimeStats = {
+    issues: computeCloseTimeMetric(issueDurations),
+    pullRequests: computeCloseTimeMetric(prDurations),
+  };
+  return NextResponse.json(stats);
+}
+
+function computeDurationMs(
+  createdAt: string | null | undefined,
+  closedAt: string | null | undefined
+): number | null {
+  if (!createdAt || !closedAt) return null;
+  const created = Date.parse(createdAt);
+  const closed = Date.parse(closedAt);
+  if (!Number.isFinite(created) || !Number.isFinite(closed)) return null;
+  const duration = closed - created;
+  return duration >= 0 ? duration : null;
+}
+
+type GithubIssueResponse = {
+  created_at: string | null;
+  closed_at: string | null;
+  pull_request?: { url: string } | null;
+};
+
 type UpstreamResult =
   | { ok: true; response: Response }
   | { ok: false; errorResponse: Response };
 
 async function fetchUpstream(
   url: URL,
-  failureMessage: string
+  failureMessage: string,
+  options: { token?: string; revalidate?: number } = {}
 ): Promise<UpstreamResult> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": USER_AGENT,
+  };
+  if (options.token) {
+    headers.Authorization = `Bearer ${options.token}`;
+  }
+  const init: RequestInit & { next?: { revalidate: number } } = { headers };
+  if (options.revalidate !== undefined) {
+    init.next = { revalidate: options.revalidate };
+  }
+
   let upstream: Response;
   try {
-    upstream = await fetch(url, {
-      headers: {
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-        "User-Agent": USER_AGENT,
-      },
-    });
+    upstream = await fetch(url, init);
   } catch {
     return {
       ok: false,

--- a/src/features/github-repo-analyzer/components/repo-detail-panel.tsx
+++ b/src/features/github-repo-analyzer/components/repo-detail-panel.tsx
@@ -97,7 +97,7 @@ export function RepoDetailPanel({ repo }: Props) {
         <div>
           <h3 className="mb-2 text-sm font-semibold">クローズ時間統計</h3>
           <p className="mb-3 text-xs text-muted-foreground">
-            直近 100 件のクローズ済み Issue / Pull Request を集計しています。
+            最近更新された 100 件のクローズ済み Issue / Pull Request を集計しています。
           </p>
           {closeLoading ? (
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/src/features/github-repo-analyzer/components/repo-detail-panel.tsx
+++ b/src/features/github-repo-analyzer/components/repo-detail-panel.tsx
@@ -10,10 +10,11 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { formatCount } from "../lib/format";
+import { formatCloseDuration, formatCount } from "../lib/format";
+import { useCloseTimeStats } from "../lib/use-close-time-stats";
 import { useRepoStats } from "../lib/use-repo-stats";
 import { LanguageBreakdown } from "./language-breakdown";
-import type { RepoSummary } from "../lib/types";
+import type { CloseTimeMetric, RepoSummary } from "../lib/types";
 
 type Props = {
   repo: RepoSummary;
@@ -22,6 +23,11 @@ type Props = {
 export function RepoDetailPanel({ repo }: Props) {
   const [owner, name] = repo.fullName.split("/");
   const { stats, error, loading } = useRepoStats(owner, name);
+  const {
+    stats: closeStats,
+    error: closeError,
+    loading: closeLoading,
+  } = useCloseTimeStats(owner, name);
 
   return (
     <Card>
@@ -87,8 +93,83 @@ export function RepoDetailPanel({ repo }: Props) {
             <LanguageBreakdown languages={stats.languages} />
           ) : null}
         </div>
+
+        <div>
+          <h3 className="mb-2 text-sm font-semibold">クローズ時間統計</h3>
+          <p className="mb-3 text-xs text-muted-foreground">
+            直近 100 件のクローズ済み Issue / Pull Request を集計しています。
+          </p>
+          {closeLoading ? (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <Skeleton className="h-24 w-full" />
+              <Skeleton className="h-24 w-full" />
+            </div>
+          ) : closeError ? (
+            <Alert variant="destructive" role="alert">
+              <AlertCircle className="size-4" />
+              <AlertTitle>クローズ時間統計の取得に失敗しました</AlertTitle>
+              <AlertDescription>{closeError.message}</AlertDescription>
+            </Alert>
+          ) : closeStats ? (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <CloseTimeCard
+                label="Issues"
+                icon={<CircleDot className="size-3.5" aria-hidden="true" />}
+                metric={closeStats.issues}
+              />
+              <CloseTimeCard
+                label="Pull Requests"
+                icon={
+                  <GitPullRequest className="size-3.5" aria-hidden="true" />
+                }
+                metric={closeStats.pullRequests}
+              />
+            </div>
+          ) : null}
+        </div>
       </CardContent>
     </Card>
+  );
+}
+
+function CloseTimeCard({
+  label,
+  icon,
+  metric,
+}: {
+  label: string;
+  icon: React.ReactNode;
+  metric: CloseTimeMetric;
+}) {
+  return (
+    <div className="rounded-md border bg-muted/30 p-3">
+      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+        {icon}
+        {label}
+      </div>
+      {metric.count === 0 ? (
+        <div className="mt-2 text-sm text-muted-foreground">データなし</div>
+      ) : (
+        <dl className="mt-2 space-y-1 text-sm">
+          <div className="flex justify-between gap-2">
+            <dt className="text-muted-foreground">平均</dt>
+            <dd className="font-medium">
+              {formatCloseDuration(metric.averageMs)}
+            </dd>
+          </div>
+          <div className="flex justify-between gap-2">
+            <dt className="text-muted-foreground">中央値</dt>
+            <dd className="font-medium">
+              {formatCloseDuration(metric.medianMs)}
+            </dd>
+          </div>
+          <div className="flex justify-between gap-2 text-xs text-muted-foreground">
+            <dt>件数</dt>
+            <dd>{metric.count}件</dd>
+          </div>
+        </dl>
+      )}
+    </div>
   );
 }
 

--- a/src/features/github-repo-analyzer/components/repo-detail-panel.tsx
+++ b/src/features/github-repo-analyzer/components/repo-detail-panel.tsx
@@ -143,7 +143,7 @@ function CloseTimeCard({
 }) {
   return (
     <div className="rounded-md border bg-muted/30 p-3">
-      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+      <div className="flex items-center gap-1 whitespace-nowrap text-xs text-muted-foreground">
         {icon}
         {label}
       </div>
@@ -184,7 +184,7 @@ function Stat({
 }) {
   return (
     <div className="rounded-md border bg-muted/30 p-3">
-      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+      <div className="flex items-center gap-1 whitespace-nowrap text-xs text-muted-foreground">
         {icon}
         {label}
       </div>

--- a/src/features/github-repo-analyzer/lib/__tests__/close-time-stats.test.ts
+++ b/src/features/github-repo-analyzer/lib/__tests__/close-time-stats.test.ts
@@ -1,0 +1,57 @@
+import { computeCloseTimeMetric } from "../close-time-stats";
+
+describe("computeCloseTimeMetric", () => {
+  it("returns zero metrics for an empty array", () => {
+    expect(computeCloseTimeMetric([])).toEqual({
+      count: 0,
+      averageMs: 0,
+      medianMs: 0,
+    });
+  });
+
+  it("returns the value as both average and median for a single entry", () => {
+    expect(computeCloseTimeMetric([1000])).toEqual({
+      count: 1,
+      averageMs: 1000,
+      medianMs: 1000,
+    });
+  });
+
+  it("computes median as the middle value for an odd count", () => {
+    expect(computeCloseTimeMetric([100, 200, 300])).toEqual({
+      count: 3,
+      averageMs: 200,
+      medianMs: 200,
+    });
+  });
+
+  it("computes median as the average of two middle values for an even count", () => {
+    expect(computeCloseTimeMetric([100, 200, 300, 400])).toEqual({
+      count: 4,
+      averageMs: 250,
+      medianMs: 250,
+    });
+  });
+
+  it("is robust to outliers via the median", () => {
+    const result = computeCloseTimeMetric([100, 200, 300, 1_000_000]);
+    expect(result.count).toBe(4);
+    expect(result.medianMs).toBe(250);
+    expect(result.averageMs).toBeGreaterThan(result.medianMs);
+  });
+
+  it("filters out negative and non-finite values", () => {
+    const result = computeCloseTimeMetric([100, -50, Number.NaN, 300]);
+    expect(result.count).toBe(2);
+    expect(result.averageMs).toBe(200);
+    expect(result.medianMs).toBe(200);
+  });
+
+  it("treats zero as a valid value", () => {
+    expect(computeCloseTimeMetric([0, 0, 100])).toEqual({
+      count: 3,
+      averageMs: 33,
+      medianMs: 0,
+    });
+  });
+});

--- a/src/features/github-repo-analyzer/lib/__tests__/format.test.ts
+++ b/src/features/github-repo-analyzer/lib/__tests__/format.test.ts
@@ -1,5 +1,6 @@
 import {
   computeLanguagePercentages,
+  formatCloseDuration,
   formatCount,
   formatRelativeDate,
 } from "../format";
@@ -66,6 +67,37 @@ describe("formatRelativeDate", () => {
 
   it("returns the original string when the date is invalid", () => {
     expect(formatRelativeDate("not-a-date", now)).toBe("not-a-date");
+  });
+});
+
+describe("formatCloseDuration", () => {
+  const HOUR = 60 * 60 * 1000;
+  const DAY = 24 * HOUR;
+
+  it("returns minutes for under one hour", () => {
+    expect(formatCloseDuration(0)).toBe("0分");
+    expect(formatCloseDuration(45 * 60_000)).toBe("45分");
+  });
+
+  it("returns hours alone when minutes are zero", () => {
+    expect(formatCloseDuration(3 * HOUR)).toBe("3時間");
+  });
+
+  it("returns hours and minutes for under one day", () => {
+    expect(formatCloseDuration(12 * HOUR + 30 * 60_000)).toBe("12時間 30分");
+  });
+
+  it("returns days alone when hours are zero", () => {
+    expect(formatCloseDuration(2 * DAY)).toBe("2日");
+  });
+
+  it("returns days and hours for over one day", () => {
+    expect(formatCloseDuration(3 * DAY + 5 * HOUR)).toBe("3日 5時間");
+  });
+
+  it("returns — for negative or non-finite values", () => {
+    expect(formatCloseDuration(-1)).toBe("—");
+    expect(formatCloseDuration(Number.NaN)).toBe("—");
   });
 });
 

--- a/src/features/github-repo-analyzer/lib/__tests__/github-client.test.ts
+++ b/src/features/github-repo-analyzer/lib/__tests__/github-client.test.ts
@@ -1,5 +1,6 @@
 import {
   GithubApiError,
+  fetchCloseTimeStats,
   fetchContributionCalendar,
   fetchRepoStats,
   fetchUserRepos,
@@ -148,6 +149,74 @@ describe("fetchRepoStats", () => {
     );
     expect(error).toBeInstanceOf(GithubApiError);
     expect((error as GithubApiError).errorCode).toBe("NOT_FOUND");
+  });
+});
+
+describe("fetchCloseTimeStats", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("returns stats on success", async () => {
+    const payload = {
+      issues: { count: 10, averageMs: 86_400_000, medianMs: 43_200_000 },
+      pullRequests: { count: 5, averageMs: 3_600_000, medianMs: 1_800_000 },
+    };
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(payload),
+    });
+    global.fetch = fetchMock;
+
+    const result = await fetchCloseTimeStats("facebook", "react");
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("mode=close-time-stats")
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("owner=facebook")
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("repo=react")
+    );
+  });
+
+  it("propagates NOT_FOUND errorCode", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: () =>
+        Promise.resolve({
+          error: "指定されたリソースが見つかりませんでした。",
+          errorCode: "NOT_FOUND",
+        }),
+    });
+
+    const error = await fetchCloseTimeStats("facebook", "nope").catch(
+      (e: unknown) => e
+    );
+    expect(error).toBeInstanceOf(GithubApiError);
+    expect((error as GithubApiError).errorCode).toBe("NOT_FOUND");
+  });
+
+  it("propagates RATE_LIMITED errorCode", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: () =>
+        Promise.resolve({
+          error: "GitHub API のレート制限に達しました。",
+          errorCode: "RATE_LIMITED",
+        }),
+    });
+
+    const error = await fetchCloseTimeStats("facebook", "react").catch(
+      (e: unknown) => e
+    );
+    expect(error).toBeInstanceOf(GithubApiError);
+    expect((error as GithubApiError).errorCode).toBe("RATE_LIMITED");
   });
 });
 

--- a/src/features/github-repo-analyzer/lib/close-time-stats.ts
+++ b/src/features/github-repo-analyzer/lib/close-time-stats.ts
@@ -1,0 +1,17 @@
+import type { CloseTimeMetric } from "./types";
+
+export function computeCloseTimeMetric(durationsMs: number[]): CloseTimeMetric {
+  const valid = durationsMs.filter((ms) => Number.isFinite(ms) && ms >= 0);
+  if (valid.length === 0) {
+    return { count: 0, averageMs: 0, medianMs: 0 };
+  }
+  const sum = valid.reduce((acc, ms) => acc + ms, 0);
+  const averageMs = Math.round(sum / valid.length);
+  const sorted = [...valid].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const medianMs =
+    sorted.length % 2 === 0
+      ? Math.round((sorted[mid - 1] + sorted[mid]) / 2)
+      : sorted[mid];
+  return { count: valid.length, averageMs, medianMs };
+}

--- a/src/features/github-repo-analyzer/lib/format.ts
+++ b/src/features/github-repo-analyzer/lib/format.ts
@@ -35,6 +35,20 @@ export function formatRelativeDate(
   return `${diffYears}年前`;
 }
 
+export function formatCloseDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  const totalMinutes = Math.floor(ms / 60_000);
+  if (totalMinutes < 60) return `${totalMinutes}分`;
+  const totalHours = Math.floor(totalMinutes / 60);
+  if (totalHours < 24) {
+    const minutes = totalMinutes % 60;
+    return minutes === 0 ? `${totalHours}時間` : `${totalHours}時間 ${minutes}分`;
+  }
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  return hours === 0 ? `${days}日` : `${days}日 ${hours}時間`;
+}
+
 export function computeLanguagePercentages(
   languages: Record<string, number>
 ): Array<{ language: string; bytes: number; percentage: number }> {

--- a/src/features/github-repo-analyzer/lib/github-client.ts
+++ b/src/features/github-repo-analyzer/lib/github-client.ts
@@ -1,5 +1,6 @@
 import type {
   ApiErrorCode,
+  CloseTimeStats,
   ContributionCalendar,
   RepoStats,
   RepoSummary,
@@ -51,6 +52,18 @@ export function fetchRepoStats(
     repo,
   });
   return request<RepoStats>(`/api/github?${params.toString()}`);
+}
+
+export function fetchCloseTimeStats(
+  owner: string,
+  repo: string
+): Promise<CloseTimeStats> {
+  const params = new URLSearchParams({
+    mode: "close-time-stats",
+    owner,
+    repo,
+  });
+  return request<CloseTimeStats>(`/api/github?${params.toString()}`);
 }
 
 export function fetchContributionCalendar(

--- a/src/features/github-repo-analyzer/lib/types.ts
+++ b/src/features/github-repo-analyzer/lib/types.ts
@@ -47,4 +47,15 @@ export type RepoStats = {
   openPullRequestCount: number;
 };
 
+export type CloseTimeMetric = {
+  count: number;
+  averageMs: number;
+  medianMs: number;
+};
+
+export type CloseTimeStats = {
+  issues: CloseTimeMetric;
+  pullRequests: CloseTimeMetric;
+};
+
 export type SortKey = "updated" | "stars";

--- a/src/features/github-repo-analyzer/lib/use-close-time-stats.ts
+++ b/src/features/github-repo-analyzer/lib/use-close-time-stats.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { GithubApiError, fetchCloseTimeStats } from "./github-client";
+import type { ApiErrorCode, CloseTimeStats } from "./types";
+
+type ErrorState = {
+  message: string;
+  errorCode?: ApiErrorCode;
+};
+
+function toErrorState(e: unknown): ErrorState {
+  if (e instanceof GithubApiError) {
+    return { message: e.message, errorCode: e.errorCode };
+  }
+  return {
+    message:
+      e instanceof Error ? e.message : "クローズ時間統計の取得に失敗しました。",
+  };
+}
+
+export function useCloseTimeStats(owner: string | null, repo: string | null) {
+  const key = owner && repo ? `${owner}/${repo}` : "";
+  const [result, setResult] = useState<{
+    data: CloseTimeStats;
+    key: string;
+  } | null>(null);
+  const [errorState, setErrorState] = useState<
+    { error: ErrorState; key: string } | null
+  >(null);
+
+  useEffect(() => {
+    if (!owner || !repo) return;
+    let cancelled = false;
+    fetchCloseTimeStats(owner, repo)
+      .then((data) => {
+        if (cancelled) return;
+        setResult({ data, key });
+        setErrorState(null);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setErrorState({ error: toErrorState(e), key });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [owner, repo, key]);
+
+  const stats = result && result.key === key ? result.data : null;
+  const error =
+    errorState && errorState.key === key ? errorState.error : null;
+  const loading = key !== "" && stats === null && error === null;
+
+  return { stats, error, loading };
+}


### PR DESCRIPTION
## Summary

- `/tools/github-repo-analyzer` の詳細パネルに「クローズ時間統計」セクションを追加し、直近 100 件の closed Issue / closed PR から平均・中央値・件数を表示
- API ルート `/api/github` に `mode=close-time-stats` を追加。`fetchUpstream` を拡張して Bearer トークン（オプトイン）と Next.js `revalidate` を渡せるように
- 集計ロジックを `lib/close-time-stats.ts` の純粋関数に切り出し、外れ値混在/空配列/偶数件の中央値などを Jest で単体テスト
- `formatCloseDuration` を追加（「3日 5時間」「12時間 30分」「45分」形式）し、`fetchCloseTimeStats` クライアント関数とフックを既存パターンに沿って追加
- サーバーサイドキャッシュは `revalidate: 3600`（1時間）。`GITHUB_TOKEN` はオプトイン利用（未設定でも未認証で動作）

Closes #186

## Test plan

- [ ] `npm run lint` / `npm run test` / `npm run build` がパスすること（実装時に確認済み）
- [ ] `/tools/github-repo-analyzer` で活発なリポジトリ（例: `vercel/next.js`）を選択し、クローズ時間統計が Issues / Pull Requests 別に「平均」「中央値」「件数」で表示されること
- [ ] クローズ済み 0 件のリポジトリで「データなし」表示になること
- [ ] 存在しないリポジトリで NOT_FOUND の Alert が表示されること
- [ ] DevTools Network タブで同一 owner/repo への切替・戻り時に Next.js fetch cache が効いていること
- [ ] `.env.local` に GITHUB_TOKEN を設定/未設定の両方で動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)