### PR TITLE
enhance: GitHub Repo Analyzer にお気に入りユーザー・リポジトリ機能を追加

### DIFF
--- a/src/features/github-repo-analyzer/components/github-favorites-list.tsx
+++ b/src/features/github-repo-analyzer/components/github-favorites-list.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { X } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { GithubFavorite } from "../lib/types";
+
+type Props = {
+  favorites: GithubFavorite[];
+  onSelectUser: (username: string) => void;
+  onSelectRepo: (fullName: string) => void;
+  onRemove: (id: string) => void;
+};
+
+export function GithubFavoritesList({
+  favorites,
+  onSelectUser,
+  onSelectRepo,
+  onRemove,
+}: Props) {
+  const users = favorites.filter((f) => f.type === "user");
+  const repos = favorites.filter((f) => f.type === "repo");
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>お気に入り</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {favorites.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            検索したユーザーやリポジトリを「お気に入り」ボタンで登録できます。
+          </p>
+        ) : (
+          <>
+            {users.length > 0 && (
+              <div className="space-y-2">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  ユーザー
+                </h3>
+                <div className="flex flex-wrap gap-2">
+                  {users.map((fav) => (
+                    <Badge
+                      key={fav.id}
+                      variant="outline"
+                      className="gap-1 px-2 py-1 font-mono text-sm"
+                    >
+                      <button
+                        type="button"
+                        onClick={() => onSelectUser(fav.value)}
+                        className="hover:underline"
+                      >
+                        @{fav.value}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onRemove(fav.id)}
+                        aria-label={`お気に入り @${fav.value} を削除`}
+                        className="ml-1 inline-flex items-center justify-center rounded-sm hover:bg-muted-foreground/20"
+                      >
+                        <X className="h-3 w-3" aria-hidden="true" />
+                      </button>
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+            {repos.length > 0 && (
+              <div className="space-y-2">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  リポジトリ
+                </h3>
+                <div className="flex flex-wrap gap-2">
+                  {repos.map((fav) => (
+                    <Badge
+                      key={fav.id}
+                      variant="outline"
+                      className="gap-1 px-2 py-1 font-mono text-sm"
+                    >
+                      <button
+                        type="button"
+                        onClick={() => onSelectRepo(fav.value)}
+                        className="hover:underline"
+                      >
+                        {fav.value}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onRemove(fav.id)}
+                        aria-label={`お気に入り ${fav.value} を削除`}
+                        className="ml-1 inline-flex items-center justify-center rounded-sm hover:bg-muted-foreground/20"
+                      >
+                        <X className="h-3 w-3" aria-hidden="true" />
+                      </button>
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/github-repo-analyzer/components/github-favorites-list.tsx
+++ b/src/features/github-repo-analyzer/components/github-favorites-list.tsx
@@ -48,7 +48,7 @@ export function GithubFavoritesList({
                       <button
                         type="button"
                         onClick={() => onSelectUser(fav.value)}
-                        className="hover:underline"
+                        className="rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                       >
                         @{fav.value}
                       </button>
@@ -56,7 +56,7 @@ export function GithubFavoritesList({
                         type="button"
                         onClick={() => onRemove(fav.id)}
                         aria-label={`お気に入り @${fav.value} を削除`}
-                        className="ml-1 inline-flex items-center justify-center rounded-sm hover:bg-muted-foreground/20"
+                        className="ml-1 inline-flex items-center justify-center rounded-sm hover:bg-muted-foreground/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                       >
                         <X className="h-3 w-3" aria-hidden="true" />
                       </button>
@@ -80,7 +80,7 @@ export function GithubFavoritesList({
                       <button
                         type="button"
                         onClick={() => onSelectRepo(fav.value)}
-                        className="hover:underline"
+                        className="rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                       >
                         {fav.value}
                       </button>
@@ -88,7 +88,7 @@ export function GithubFavoritesList({
                         type="button"
                         onClick={() => onRemove(fav.id)}
                         aria-label={`お気に入り ${fav.value} を削除`}
-                        className="ml-1 inline-flex items-center justify-center rounded-sm hover:bg-muted-foreground/20"
+                        className="ml-1 inline-flex items-center justify-center rounded-sm hover:bg-muted-foreground/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                       >
                         <X className="h-3 w-3" aria-hidden="true" />
                       </button>

--- a/src/features/github-repo-analyzer/components/github-repo-analyzer-page.tsx
+++ b/src/features/github-repo-analyzer/components/github-repo-analyzer-page.tsx
@@ -3,24 +3,77 @@
 import { useState } from "react";
 import { AlertCircle } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useGithubFavorites } from "../lib/use-github-favorites";
 import { useGithubRepos } from "../lib/use-github-repos";
 import type { RepoSummary, SortKey } from "../lib/types";
 import { ContributionHeatmap } from "./contribution-heatmap";
+import { GithubFavoritesList } from "./github-favorites-list";
 import { RepoDetailPanel } from "./repo-detail-panel";
 import { RepoList } from "./repo-list";
+import { UserFavoriteToggle } from "./user-favorite-toggle";
 import { UsernameSearchForm } from "./username-search-form";
 
 export function GithubRepoAnalyzerPage() {
   const [username, setUsername] = useState("");
   const [sort, setSort] = useState<SortKey>("updated");
   const [selectedRepo, setSelectedRepo] = useState<RepoSummary | null>(null);
+  const [pendingRepoSelection, setPendingRepoSelection] = useState<
+    string | null
+  >(null);
 
   const { repos, error, loading } = useGithubRepos(username, sort);
+  const favorites = useGithubFavorites();
+
+  const displayedRepo =
+    selectedRepo ??
+    (pendingRepoSelection && repos
+      ? repos.find((r) => r.fullName === pendingRepoSelection) ?? null
+      : null);
 
   const handleSubmit = (next: string) => {
     setUsername(next);
     setSelectedRepo(null);
+    setPendingRepoSelection(null);
   };
+
+  const handleToggleUserFavorite = () => {
+    if (!username) return;
+    const existing = favorites.favorites.find(
+      (f) => f.type === "user" && f.value === username
+    );
+    if (existing) {
+      favorites.remove(existing.id);
+    } else {
+      favorites.add("user", username);
+    }
+  };
+
+  const handleToggleRepoFavorite = (repo: RepoSummary) => {
+    const existing = favorites.favorites.find(
+      (f) => f.type === "repo" && f.value === repo.fullName
+    );
+    if (existing) {
+      favorites.remove(existing.id);
+    } else {
+      favorites.add("repo", repo.fullName);
+    }
+  };
+
+  const handleSelectFavoriteUser = (value: string) => {
+    setUsername(value);
+    setSelectedRepo(null);
+    setPendingRepoSelection(null);
+  };
+
+  const handleSelectFavoriteRepo = (fullName: string) => {
+    const [owner] = fullName.split("/");
+    if (!owner) return;
+    setUsername(owner);
+    setSelectedRepo(null);
+    setPendingRepoSelection(fullName);
+  };
+
+  const isUserFavorite = favorites.has("user", username);
 
   return (
     <div className="space-y-6">
@@ -33,7 +86,26 @@ export function GithubRepoAnalyzerPage() {
         </p>
       </div>
 
-      <UsernameSearchForm onSubmit={handleSubmit} />
+      <UsernameSearchForm
+        key={username}
+        onSubmit={handleSubmit}
+        initialValue={username}
+      />
+
+      {username && (
+        <UserFavoriteToggle
+          username={username}
+          isFavorite={isUserFavorite}
+          onToggle={handleToggleUserFavorite}
+        />
+      )}
+
+      <GithubFavoritesList
+        favorites={favorites.favorites}
+        onSelectUser={handleSelectFavoriteUser}
+        onSelectRepo={handleSelectFavoriteRepo}
+        onRemove={favorites.remove}
+      />
 
       {username && <ContributionHeatmap username={username} />}
 
@@ -50,14 +122,19 @@ export function GithubRepoAnalyzerPage() {
           <RepoList
             repos={repos}
             loading={loading}
-            selectedRepoId={selectedRepo?.id ?? null}
-            onSelect={setSelectedRepo}
+            selectedRepoId={displayedRepo?.id ?? null}
+            onSelect={(repo) => {
+              setSelectedRepo(repo);
+              setPendingRepoSelection(null);
+            }}
             sort={sort}
             onSortChange={setSort}
+            getIsFavorite={(repo) => favorites.has("repo", repo.fullName)}
+            onToggleFavorite={handleToggleRepoFavorite}
           />
           <div>
-            {selectedRepo ? (
-              <RepoDetailPanel repo={selectedRepo} />
+            {displayedRepo ? (
+              <RepoDetailPanel repo={displayedRepo} />
             ) : (
               <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
                 リポジトリを選択すると詳細が表示されます。

--- a/src/features/github-repo-analyzer/components/repo-card.tsx
+++ b/src/features/github-repo-analyzer/components/repo-card.tsx
@@ -10,45 +10,73 @@ type Props = {
   repo: RepoSummary;
   selected: boolean;
   onSelect: (repo: RepoSummary) => void;
+  isFavorite: boolean;
+  onToggleFavorite: (repo: RepoSummary) => void;
 };
 
-export function RepoCard({ repo, selected, onSelect }: Props) {
+export function RepoCard({
+  repo,
+  selected,
+  onSelect,
+  isFavorite,
+  onToggleFavorite,
+}: Props) {
   return (
-    <button
-      type="button"
-      onClick={() => onSelect(repo)}
-      aria-pressed={selected}
+    <div
       className={cn(
-        "w-full rounded-lg border bg-card p-4 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        "relative rounded-lg border bg-card transition-colors",
         selected && "border-primary ring-2 ring-primary"
       )}
     >
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0 flex-1">
-          <h3 className="truncate font-semibold">{repo.name}</h3>
-          {repo.description && (
-            <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
-              {repo.description}
-            </p>
-          )}
+      <button
+        type="button"
+        onClick={() => onSelect(repo)}
+        aria-pressed={selected}
+        className="w-full rounded-lg p-4 pr-12 text-left hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <h3 className="truncate font-semibold">{repo.name}</h3>
+            {repo.description && (
+              <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                {repo.description}
+              </p>
+            )}
+          </div>
+          <div className="flex shrink-0 flex-col items-end gap-1">
+            {repo.isArchived && <Badge variant="secondary">Archived</Badge>}
+            {repo.isFork && <Badge variant="outline">Fork</Badge>}
+          </div>
         </div>
-        <div className="flex shrink-0 flex-col items-end gap-1">
-          {repo.isArchived && <Badge variant="secondary">Archived</Badge>}
-          {repo.isFork && <Badge variant="outline">Fork</Badge>}
+        <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
+          {repo.language && <span>{repo.language}</span>}
+          <span className="inline-flex items-center gap-1">
+            <Star className="size-3.5" aria-hidden="true" />
+            {formatCount(repo.stargazersCount)}
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <GitFork className="size-3.5" aria-hidden="true" />
+            {formatCount(repo.forksCount)}
+          </span>
+          <span>更新 {formatRelativeDate(repo.updatedAt)}</span>
         </div>
-      </div>
-      <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
-        {repo.language && <span>{repo.language}</span>}
-        <span className="inline-flex items-center gap-1">
-          <Star className="size-3.5" aria-hidden="true" />
-          {formatCount(repo.stargazersCount)}
-        </span>
-        <span className="inline-flex items-center gap-1">
-          <GitFork className="size-3.5" aria-hidden="true" />
-          {formatCount(repo.forksCount)}
-        </span>
-        <span>更新 {formatRelativeDate(repo.updatedAt)}</span>
-      </div>
-    </button>
+      </button>
+      <button
+        type="button"
+        onClick={() => onToggleFavorite(repo)}
+        aria-pressed={isFavorite}
+        aria-label={
+          isFavorite
+            ? `${repo.fullName} をお気に入りから削除`
+            : `${repo.fullName} をお気に入りに追加`
+        }
+        className="absolute right-2 top-2 inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <Star
+          className={cn("size-4", isFavorite && "fill-current text-yellow-500")}
+          aria-hidden="true"
+        />
+      </button>
+    </div>
   );
 }

--- a/src/features/github-repo-analyzer/components/repo-list.tsx
+++ b/src/features/github-repo-analyzer/components/repo-list.tsx
@@ -11,6 +11,8 @@ type Props = {
   onSelect: (repo: RepoSummary) => void;
   sort: SortKey;
   onSortChange: (sort: SortKey) => void;
+  getIsFavorite: (repo: RepoSummary) => boolean;
+  onToggleFavorite: (repo: RepoSummary) => void;
 };
 
 export function RepoList({
@@ -20,6 +22,8 @@ export function RepoList({
   onSelect,
   sort,
   onSortChange,
+  getIsFavorite,
+  onToggleFavorite,
 }: Props) {
   const sortedRepos = repos
     ? [...repos].sort((a, b) => {
@@ -75,6 +79,8 @@ export function RepoList({
               repo={repo}
               selected={repo.id === selectedRepoId}
               onSelect={onSelect}
+              isFavorite={getIsFavorite(repo)}
+              onToggleFavorite={onToggleFavorite}
             />
           ))}
         </div>

--- a/src/features/github-repo-analyzer/components/user-favorite-toggle.tsx
+++ b/src/features/github-repo-analyzer/components/user-favorite-toggle.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Star } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  username: string;
+  isFavorite: boolean;
+  onToggle: () => void;
+};
+
+export function UserFavoriteToggle({ username, isFavorite, onToggle }: Props) {
+  return (
+    <div className="flex items-center justify-between gap-2 rounded-md border bg-card px-4 py-2 text-sm">
+      <span className="truncate text-muted-foreground">
+        検索中: <span className="font-mono text-foreground">@{username}</span>
+      </span>
+      <Button
+        type="button"
+        size="sm"
+        variant={isFavorite ? "default" : "outline"}
+        onClick={onToggle}
+        aria-pressed={isFavorite}
+      >
+        <Star
+          className={cn("size-4", isFavorite && "fill-current")}
+          aria-hidden="true"
+        />
+        {isFavorite ? "お気に入り済み" : "お気に入り"}
+      </Button>
+    </div>
+  );
+}

--- a/src/features/github-repo-analyzer/lib/__tests__/use-github-favorites.test.ts
+++ b/src/features/github-repo-analyzer/lib/__tests__/use-github-favorites.test.ts
@@ -1,0 +1,95 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useGithubFavorites } from "../use-github-favorites";
+
+const STORAGE_KEY = "github-repo-analyzer:favorites";
+
+describe("useGithubFavorites", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("starts empty when localStorage has no entries", async () => {
+    const { result } = renderHook(() => useGithubFavorites());
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+    expect(result.current.favorites).toEqual([]);
+  });
+
+  it("hydrates from localStorage on mount", async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        { id: "u1", type: "user", value: "facebook" },
+        { id: "r1", type: "repo", value: "facebook/react" },
+      ])
+    );
+
+    const { result } = renderHook(() => useGithubFavorites());
+    await waitFor(() => expect(result.current.favorites).toHaveLength(2));
+    expect(result.current.has("user", "facebook")).toBe(true);
+    expect(result.current.has("repo", "facebook/react")).toBe(true);
+  });
+
+  it("ignores corrupt JSON in localStorage", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "{not json");
+
+    const { result } = renderHook(() => useGithubFavorites());
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+    expect(result.current.favorites).toEqual([]);
+  });
+
+  it("adds user and repo favorites and persists to localStorage", async () => {
+    const { result } = renderHook(() => useGithubFavorites());
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+
+    act(() => {
+      result.current.add("user", "facebook");
+    });
+    act(() => {
+      result.current.add("repo", "facebook/react");
+    });
+
+    expect(result.current.favorites).toHaveLength(2);
+    expect(result.current.has("user", "facebook")).toBe(true);
+    expect(result.current.has("repo", "facebook/react")).toBe(true);
+
+    const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "[]");
+    expect(stored).toHaveLength(2);
+    expect(stored).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "user", value: "facebook" }),
+        expect.objectContaining({ type: "repo", value: "facebook/react" }),
+      ])
+    );
+  });
+
+  it("does not add a duplicate favorite", async () => {
+    const { result } = renderHook(() => useGithubFavorites());
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+
+    act(() => {
+      result.current.add("user", "facebook");
+    });
+    act(() => {
+      result.current.add("user", "facebook");
+    });
+
+    expect(result.current.favorites).toHaveLength(1);
+  });
+
+  it("removes a favorite by id", async () => {
+    const { result } = renderHook(() => useGithubFavorites());
+    await waitFor(() => expect(result.current.hydrated).toBe(true));
+
+    act(() => {
+      result.current.add("repo", "facebook/react");
+    });
+    const id = result.current.favorites[0].id;
+
+    act(() => {
+      result.current.remove(id);
+    });
+
+    expect(result.current.favorites).toEqual([]);
+    expect(result.current.has("repo", "facebook/react")).toBe(false);
+  });
+});

--- a/src/features/github-repo-analyzer/lib/types.ts
+++ b/src/features/github-repo-analyzer/lib/types.ts
@@ -59,3 +59,11 @@ export type CloseTimeStats = {
 };
 
 export type SortKey = "updated" | "stars";
+
+export type FavoriteType = "user" | "repo";
+
+export type GithubFavorite = {
+  id: string;
+  type: FavoriteType;
+  value: string;
+};

--- a/src/features/github-repo-analyzer/lib/use-github-favorites.ts
+++ b/src/features/github-repo-analyzer/lib/use-github-favorites.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { FavoriteType, GithubFavorite } from "./types";
+
+const STORAGE_KEY = "github-repo-analyzer:favorites";
+
+function isGithubFavorite(value: unknown): value is GithubFavorite {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === "string" &&
+    (v.type === "user" || v.type === "repo") &&
+    typeof v.value === "string"
+  );
+}
+
+function loadFromStorage(): GithubFavorite[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isGithubFavorite);
+  } catch {
+    return [];
+  }
+}
+
+export function useGithubFavorites() {
+  const [favorites, setFavorites] = useState<GithubFavorite[]>([]);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    // localStorage はクライアント側のみで参照できる外部システムのため、
+    // マウント後の同期は副作用として扱う必要がある。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setFavorites(loadFromStorage());
+    setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(favorites));
+    } catch {
+      // ignore quota / serialization errors
+    }
+  }, [favorites, hydrated]);
+
+  const has = useCallback(
+    (type: FavoriteType, value: string) =>
+      favorites.some((f) => f.type === type && f.value === value),
+    [favorites]
+  );
+
+  const add = useCallback((type: FavoriteType, value: string) => {
+    setFavorites((prev) => {
+      if (prev.some((f) => f.type === type && f.value === value)) return prev;
+      return [...prev, { id: crypto.randomUUID(), type, value }];
+    });
+  }, []);
+
+  const remove = useCallback((id: string) => {
+    setFavorites((prev) => prev.filter((f) => f.id !== id));
+  }, []);
+
+  return { favorites, hydrated, has, add, remove };
+}


### PR DESCRIPTION
## Summary
- 検索したユーザー / リポジトリ (`owner/repo`) を localStorage に永続化する `useGithubFavorites` フックを追加（参考: `use-favorite-pairs.ts`）
- 検索フォーム直下にユーザーお気に入りトグル、その下にお気に入り一覧 Card を配置（user / repo セクション分け表示）
- `RepoCard` の右上に星トグルを追加（ルートを `<div>` 化してメイン content と兄弟ボタンに分離）
- リポジトリお気に入りクリック時は `setUsername(owner)` 後、`displayedRepo` を `selectedRepo ?? repos.find(fullName 一致)` で導出して自動選択
- `useGithubFavorites` のユニットテスト 6 ケース追加（初期空 / hydration / 破損 JSON / add 永続化 / 重複抑止 / remove）

Closes #187

## Test plan
- [ ] `npm run lint` / `npm run test` / `npm run build` がすべて成功する
- [ ] `/tools/github-repo-analyzer` でユーザー名検索 → フォーム直下に「@username をお気に入りに登録」が表示される
- [ ] ユーザー星トグル → 一覧 Card に user バッジが追加され、ページ再読み込み後も保持される
- [ ] `RepoCard` 右上の星アイコン → クリックで切り替わり、一覧 Card に repo バッジが追加される
- [ ] 一覧 Card の user バッジクリック → そのユーザーで再検索される
- [ ] 一覧 Card の repo バッジクリック → owner で再検索後、該当リポジトリが自動選択され `RepoDetailPanel` が開く
- [ ] 各バッジの `X` ボタンで削除できる
- [ ] DevTools の Application → Local Storage で `github-repo-analyzer:favorites` の JSON が `{ id, type, value }[]` 形式で永続化されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)